### PR TITLE
Improve interrupt handling and device analysis abort

### DIFF
--- a/device/device_menu.py
+++ b/device/device_menu.py
@@ -54,6 +54,9 @@ def interactive_device_menu(device: DeviceInfo):
             log.info(f"Launching static analysis for {serial}")
             run_static_analysis.analyze_device(serial)   # <-- call into analysis
             log.info(f"Static analysis finished for {serial}")
+        except KeyboardInterrupt:
+            print("\n⚠️  Static analysis interrupted. Returning to menu.\n")
+            log.warning(f"Static analysis interrupted for {serial}")
         except Exception as e:
             print(f"❌ Static analysis failed: {e}")
             log.error(f"Static analysis failed for {serial}: {e}")

--- a/main.py
+++ b/main.py
@@ -36,9 +36,9 @@ def action_database_menu():
 
 def handle_interrupt(sig, frame):
     """Gracefully handle Ctrl+C interrupts."""
-    print("\n\n⚠️  Interrupted by user. Exiting...")
+    print("\n\n⚠️  Interrupted by user.")
     log.warning("Application interrupted with Ctrl+C")
-    sys.exit(0)
+    raise KeyboardInterrupt
 
 
 # ---------- Main Entry ----------

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 # run.sh - launcher for Android Tool
 
-# run Python app, handle Ctrl+C gracefully
-trap 'echo -e "\n\n⚠️  Interrupted. Exiting..."; exit 130' INT
-
+# Run the Python application; allow Ctrl+C to be handled by Python
 python3 main.py


### PR DESCRIPTION
## Summary
- allow Python to handle SIGINT by removing shell trap
- raise `KeyboardInterrupt` in `main.handle_interrupt`
- handle Ctrl+C during static analysis to return to device menu

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `bash -n run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a777353c808327af33d7a5ede0dbe1