### PR TITLE
Fix device menu exit logic

### DIFF
--- a/device/device_menu.py
+++ b/device/device_menu.py
@@ -7,6 +7,7 @@ from utils.adb_utils import adb_ip_lookup
 from utils.adb_utils.adb_devices import DeviceInfo
 from device import vendor_normalizer
 from utils.display_utils import prompt_utils, menu_utils
+from utils.display_utils.menu_utils import MenuExit
 from analysis.static_analysis import run_static_analysis   # <-- import
 import utils.logging_utils.logging_engine as log
 
@@ -65,8 +66,7 @@ def interactive_device_menu(device: DeviceInfo):
         if prompt_utils.ask_yes_no(f"Disconnect from {serial}?", default="y"):
             print(f"\n🔌 Disconnected from {serial}")
             log.info(f"Disconnected from {serial}")
-            return True
-        return False
+            raise MenuExit
 
     def reboot():
         if prompt_utils.ask_yes_no(f"Reboot {serial}?", default="y"):
@@ -89,9 +89,5 @@ def interactive_device_menu(device: DeviceInfo):
         "6": ("Exit program", exit_program),
     }
 
-    while True:
-        choice = menu_utils.show_menu("Device Menu", options, exit_label="Back")
-        log.debug(f"Menu choice {choice} selected for device {serial}")
-        if choice == "4" and disconnect():
-            break
+    menu_utils.show_menu("Device Menu", options, exit_label="Back")
     log.info(f"Exiting device menu for {serial}")

--- a/utils/display_utils/menu_utils.py
+++ b/utils/display_utils/menu_utils.py
@@ -4,6 +4,11 @@ import sys
 from typing import Callable, Dict, Tuple, List, Optional
 from utils.display_utils import prompt_utils, error_utils
 
+
+class MenuExit(Exception):
+    """Signal that the current menu should exit early."""
+    pass
+
 try:
     from colorama import Fore, Style, init as colorama_init
     colorama_init(autoreset=True)
@@ -75,7 +80,10 @@ def show_menu(
             break
 
         label, action = options[choice]
-        run_menu_action(label, action)
+        try:
+            run_menu_action(label, action)
+        except MenuExit:
+            break
 
 
 # ---------- Action Helpers ----------
@@ -85,6 +93,8 @@ def run_menu_action(label: str, action: Callable) -> None:
     try:
         print(f"\n▶ Running: {label}\n")
         action()
+    except MenuExit:
+        raise
     except Exception as e:
         error_utils.handle_error(f"Error while running '{label}': {e}", exc=e)
 


### PR DESCRIPTION
## Summary
- add `MenuExit` exception to allow menus to break out
- raise `MenuExit` on disconnect and rely on `show_menu`'s loop

## Testing
- `pytest`
- `python -m py_compile device/device_menu.py utils/display_utils/menu_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7760b5c888327bd38aeab5fb2e4a7