### PR TITLE
Enable verbose logging and debug ADB command tracking

### DIFF
--- a/logs/android_tool.log
+++ b/logs/android_tool.log
@@ -1,0 +1,47 @@
+2025-08-21 20:49:47 | DEBUG | root | Fetching full package dump for ABC123
+2025-08-21 20:49:47 | INFO | root | Parsed permissions for 2 packages in total
+2025-08-21 20:49:47 | DEBUG | root | Listing APK paths for ABC123
+2025-08-21 20:49:47 | INFO | root | Discovered APK paths for 1 packages on ABC123
+2025-08-21 20:49:47 | INFO | root | Validating APK paths for 2 packages
+2025-08-21 20:49:47 | DEBUG | root | APK for com.example.one located at /data/app/com.example.one-1/base.apk
+2025-08-21 20:49:47 | WARNING | root | No APK path found for com.example.two
+2025-08-21 20:49:47 | INFO | root | Validated 2/2 packages
+2025-08-21 20:49:47 | INFO | root | Skipping 1 packages without APKs
+2025-08-21 20:49:47 | INFO | root | Computing hashes for 1 packages
+2025-08-21 20:49:47 | DEBUG | root | Hash for com.example.one: hashone
+2025-08-21 20:49:47 | INFO | root | Hashed 1/1 packages
+2025-08-21 20:49:47 | INFO | root | Analyzing 1 packages on ABC123
+2025-08-21 20:49:47 | INFO | root | Processed 1/1 packages
+2025-08-21 20:49:47 | INFO | root | Generated 1 package reports for ABC123; flagged 1 at-risk apps
+2025-08-21 20:49:47 | DEBUG | root | Fetching full package dump for ABC123
+2025-08-21 20:49:47 | WARNING | root | No package data found for ABC123
+2025-08-21 20:49:47 | DEBUG | root | Listing APK paths for ABC123
+2025-08-21 20:49:47 | WARNING | root | No APK paths found for ABC123
+2025-08-21 20:49:47 | INFO | root | Validating APK paths for 0 packages
+2025-08-21 20:49:47 | INFO | root | Computing hashes for 0 packages
+2025-08-21 20:49:47 | INFO | root | Analyzing 0 packages on ABC123
+2025-08-21 20:49:47 | INFO | root | Generated 0 package reports for ABC123; flagged 0 at-risk apps
+2025-08-21 20:49:47 | DEBUG | root | Fetching full package dump for ABC123
+2025-08-21 20:49:47 | INFO | root | Parsed permissions for 2 packages in total
+2025-08-21 20:49:47 | DEBUG | root | Listing APK paths for ABC123
+2025-08-21 20:49:47 | INFO | root | Discovered APK paths for 2 packages on ABC123
+2025-08-21 20:49:47 | INFO | root | Validating APK paths for 2 packages
+2025-08-21 20:49:47 | DEBUG | root | APK for com.example.one located at /data/app/com.example.one-1/base.apk
+2025-08-21 20:49:47 | DEBUG | root | APK for com.example.two located at /data/app/com.example.two-1/base.apk
+2025-08-21 20:49:47 | INFO | root | Validated 2/2 packages
+2025-08-21 20:49:47 | INFO | root | Computing hashes for 2 packages
+2025-08-21 20:49:47 | DEBUG | root | Hash for com.example.one: hashone
+2025-08-21 20:49:47 | DEBUG | root | Hash for com.example.two: hashtwo
+2025-08-21 20:49:47 | INFO | root | Hashed 2/2 packages
+2025-08-21 20:49:47 | INFO | root | Analyzing 2 packages on ABC123
+2025-08-21 20:49:47 | INFO | root | Processed 2/2 packages
+2025-08-21 20:49:47 | INFO | root | Generated 2 package reports for ABC123; flagged 2 at-risk apps
+2025-08-21 20:49:47 | DEBUG | root | Device 1: {'index': 1, 'serial': 'ABC123', 'type': 'Physical', 'vendor': 'Google', 'model': 'Pixel 4', 'state': 'device', 'ip': '1.2.3.4'}
+2025-08-21 20:49:47 | DEBUG | root | Device 2: {'index': 2, 'serial': 'XYZ789', 'type': 'Physical', 'vendor': 'Lg', 'model': 'Nexus 5', 'state': 'offline', 'ip': '1.2.3.4'}
+2025-08-21 20:49:47 | DEBUG | root | Device 1: {'index': 1, 'serial': 'ABC123', 'type': 'Physical', 'vendor': 'Google', 'model': 'Pixel 4', 'state': 'device', 'ip': '1.2.3.4'}
+2025-08-21 20:49:47 | DEBUG | root | Device 2: {'index': 2, 'serial': 'XYZ789', 'type': 'Physical', 'vendor': 'Lg', 'model': 'Nexus 5', 'state': 'offline', 'ip': '1.2.3.4'}
+2025-08-21 20:49:47 | DEBUG | root | Device 1: {'index': 1, 'serial': 'ABC123', 'type': 'Physical', 'vendor': 'Google', 'model': 'Pixel 4', 'state': 'device', 'ip': '1.2.3.4'}
+2025-08-21 20:49:47 | DEBUG | root | Device 2: {'index': 2, 'serial': 'XYZ789', 'type': 'Physical', 'vendor': 'Lg', 'model': 'Nexus 5', 'state': 'offline', 'ip': '1.2.3.4'}
+2025-08-21 20:49:47 | DEBUG | root | Device 1: {'index': 1, 'serial': 'ABC123', 'type': 'Physical', 'vendor': 'Google', 'model': 'Pixel 4', 'state': 'device', 'ip': '1.2.3.4'}
+2025-08-21 20:49:47 | DEBUG | root | Device 2: {'index': 2, 'serial': 'XYZ789', 'type': 'Physical', 'vendor': 'Lg', 'model': 'Nexus 5', 'state': 'offline', 'ip': '1.2.3.4'}
+2025-08-21 20:49:47 | WARNING | root | IP lookup failed for ABC123: boom

--- a/main.py
+++ b/main.py
@@ -1,6 +1,8 @@
 # main.py
 import sys
 import signal
+import argparse
+import logging
 
 from config import app_config
 from utils.display_utils import menu_utils, error_utils
@@ -52,6 +54,17 @@ def handle_interrupt(sig, frame):
 
 def main():
     """Main entry point for the Android Tool CLI."""
+    parser = argparse.ArgumentParser(description="Android Tool CLI")
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable debug logging to console",
+    )
+    args = parser.parse_args()
+
+    if args.verbose:
+        log.set_console_level(logging.DEBUG)
+
     # Trap Ctrl+C
     signal.signal(signal.SIGINT, handle_interrupt)
 

--- a/run.sh
+++ b/run.sh
@@ -2,4 +2,4 @@
 # run.sh - launcher for Android Tool
 
 # Run the Python application; allow Ctrl+C to be handled by Python
-python3 main.py
+python3 main.py "$@"

--- a/utils/adb_utils/adb_runner.py
+++ b/utils/adb_utils/adb_runner.py
@@ -30,7 +30,7 @@ def execute_command(
             "error": str (error message if failed)
         }
     """
-    log.info(f"[EXECUTE] Running command: {' '.join(cmd)}")
+    log.debug(f"[EXECUTE] Running command: {' '.join(cmd)}")
 
     try:
         result = subprocess.run(

--- a/utils/logging_utils/logging_core.py
+++ b/utils/logging_utils/logging_core.py
@@ -5,7 +5,13 @@ from pathlib import Path
 
 
 class LoggingCore:
-    def __init__(self, log_name="android_tool", log_dir="logs", level=logging.INFO):
+    def __init__(self, log_name: str = "android_tool", log_dir: str = "logs"):
+        """Configure application-wide logging.
+
+        A root logger is created at DEBUG level. Console output defaults to
+        INFO while the log file captures DEBUG and above.
+        """
+
         # ensure logs directory exists
         self.log_dir = Path(log_dir)
         self.log_dir.mkdir(parents=True, exist_ok=True)
@@ -13,9 +19,9 @@ class LoggingCore:
         # file path for logs
         log_file = self.log_dir / f"{log_name}.log"
 
-        # create logger
-        self.logger = logging.getLogger(log_name)
-        self.logger.setLevel(level)
+        # configure root logger
+        self.logger = logging.getLogger()
+        self.logger.setLevel(logging.DEBUG)
 
         # formatter for logs
         formatter = logging.Formatter(
@@ -23,15 +29,22 @@ class LoggingCore:
             "%Y-%m-%d %H:%M:%S",
         )
 
-        # console handler
-        console_handler = logging.StreamHandler()
-        console_handler.setFormatter(formatter)
-        self.logger.addHandler(console_handler)
+        # console handler at INFO by default
+        self.console_handler = logging.StreamHandler()
+        self.console_handler.setLevel(logging.INFO)
+        self.console_handler.setFormatter(formatter)
+        self.logger.addHandler(self.console_handler)
 
-        # file handler
+        # file handler captures DEBUG messages
         file_handler = logging.FileHandler(log_file, encoding="utf-8")
+        file_handler.setLevel(logging.DEBUG)
         file_handler.setFormatter(formatter)
         self.logger.addHandler(file_handler)
+
+    def set_console_level(self, level: int) -> None:
+        """Adjust the console handler log level."""
+
+        self.console_handler.setLevel(level)
 
     def get_logger(self):
         # return the logger instance

--- a/utils/logging_utils/logging_engine.py
+++ b/utils/logging_utils/logging_engine.py
@@ -31,3 +31,9 @@ def debug(message: str):
 def critical(message: str):
     # log critical issues
     _logger.critical(message)
+
+
+def set_console_level(level: int) -> None:
+    """Expose ability to tweak console log level at runtime."""
+
+    _core.set_console_level(level)


### PR DESCRIPTION
## Summary
- Log ADB command execution at debug level
- Configure logging system for debug retention in logs with optional console verbosity
- Add `--verbose` CLI flag and forward script arguments

## Testing
- `pytest -q`
- `python3 main.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68a785ee3b2c8327a7f02b052e7a63ad