### PR TITLE
Enhance menu display and selection highlighting

### DIFF
--- a/tests/test_menu_render.py
+++ b/tests/test_menu_render.py
@@ -34,3 +34,18 @@ def test_selected_option_emphasis(capsys):
     out = capsys.readouterr().out
     assert "Start" in out
     assert theme.color("fg.accent") in out
+
+
+def test_highlight_inverse_with_arrow(capsys):
+    menu_utils.print_menu_options({"1": ("Start", dummy)}, "Exit", highlight="1")
+    out = capsys.readouterr().out
+    assert "\x1b[7m" in out  # inverse video applied
+    assert "▶ [1] Start" in strip_ansi(out)
+
+
+def test_highlight_accent_style(capsys):
+    menu_utils.print_menu_options(
+        {"1": ("Start", dummy)}, "Exit", highlight="1", highlight_style="accent"
+    )
+    out = capsys.readouterr().out
+    assert theme.color("fg.accent") in out


### PR DESCRIPTION
## Summary
- allow menu option highlighting with configurable style tokens (inverse, bold, accent)
- prepend a standout pointer to highlighted entries for clearer focus
- expand menu rendering tests to cover arrow and accent highlighting

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a787c22fdc8327ac64842e755643b4