### PR TITLE
Add progress ticker and secret scanning heuristics

### DIFF
--- a/analysis/static_analysis/secret_scanner.py
+++ b/analysis/static_analysis/secret_scanner.py
@@ -1,0 +1,53 @@
+"""Pattern-based secret scanner for static analysis.
+
+This module defines regular expressions for common API keys or tokens and
+exposes a :func:`scan` helper that returns all matches grouped by type.
+The goal is to complement the basic keyword search in :mod:`string_finder`
+with more targeted heuristics so analysis can surface likely credentials
+or secrets.
+"""
+from __future__ import annotations
+
+import re
+from typing import Dict, List, Mapping
+
+# Registry of token patterns to search for in APK strings
+PATTERNS: Mapping[str, re.Pattern[str]] = {
+    "aws_access_key": re.compile(r"AKIA[0-9A-Z]{16}"),
+    "aws_secret_key": re.compile(
+        r"(?i)aws_secret_access_key\s*[:=]\s*['\"]?[A-Za-z0-9/+=]{40}"
+    ),
+    "google_api_key": re.compile(r"AIza[0-9A-Za-z_-]{35}"),
+    "slack_token": re.compile(r"xox[baprs]-[0-9A-Za-z-]{10,48}"),
+    "github_token": re.compile(r"ghp_[0-9A-Za-z]{36}"),
+    "jwt_token": re.compile(
+        r"eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}"
+    ),
+    "private_key": re.compile(r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----"),
+    # Generic `secret = value` style assignments with long values
+    "generic_secret": re.compile(r"(?:secret|token|key)\s*[:=]\s*['\"]?[0-9A-Za-z_-]{8,}"),
+}
+
+
+def scan(text: str) -> Dict[str, List[str]]:
+    """Return all pattern matches found within ``text``.
+
+    Parameters
+    ----------
+    text: str
+        Input string to search.
+
+    Returns
+    -------
+    Dict[str, List[str]]
+        Mapping from pattern name to list of matched strings. Patterns with no
+        matches are omitted from the result.
+    """
+    results: Dict[str, List[str]] = {}
+    for name, pattern in PATTERNS.items():
+        hits = pattern.findall(text)
+        if hits:
+            results[name] = hits
+    return results
+
+__all__ = ["scan", "PATTERNS"]

--- a/analysis/static_analysis/tests/test_package_analysis.py
+++ b/analysis/static_analysis/tests/test_package_analysis.py
@@ -23,7 +23,16 @@ class PackageAnalysisTests(unittest.TestCase):
         def fake_run_adb_command(serial, cmd):
             if cmd == ["shell", "dumpsys", "package"]:
                 return {"success": True, "output": dumpsys_output}
-            if cmd == ["shell", "pm", "list", "packages", "-f"]:
+            if cmd == [
+                "shell",
+                "pm",
+                "list",
+                "packages",
+                "-f",
+                "-u",
+                "--user",
+                "0",
+            ]:
                 return {"success": True, "output": pm_list_output}
             if len(cmd) == 3 and cmd[0] == "shell" and cmd[1] == "sha256sum":
                 path = cmd[2]

--- a/analysis/static_analysis/tests/test_secret_scanner.py
+++ b/analysis/static_analysis/tests/test_secret_scanner.py
@@ -1,0 +1,29 @@
+from analysis.static_analysis.secret_scanner import scan
+
+
+def test_detects_common_tokens():
+    text = (
+        "This string has an AWS key AKIA1234567890ABCDEF and a Google key "
+        "AIzaSyA-12345678901234567890123456789012 plus a Slack token "
+        "xoxb-123456789012-abcdefGhijkl and a GitHub token "
+        "ghp_1234567890abcdef1234567890abcdef1234."
+    )
+    results = scan(text)
+    assert results["aws_access_key"] == ["AKIA1234567890ABCDEF"]
+    assert results["google_api_key"], "Should detect Google API key"
+    assert any(token.startswith("xoxb-") for token in results["slack_token"])
+    assert results["github_token"][0].startswith("ghp_")
+
+
+def test_detects_jwt_private_and_secret_key():
+    text = (
+        "aws_secret_access_key=ABCD1234ABCD1234ABCD1234ABCD1234ABCD1234 "
+        "Token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+        "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ."
+        "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c ----"
+        "-----BEGIN PRIVATE KEY-----"
+    )
+    results = scan(text)
+    assert results["aws_secret_key"], "Should detect AWS secret access key"
+    assert results["jwt_token"], "Should detect JWT token"
+    assert results["private_key"], "Should detect private key block"

--- a/utils/display_utils/progress.py
+++ b/utils/display_utils/progress.py
@@ -1,0 +1,49 @@
+"""Utilities for updating a single-line console progress ticker."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Mapping
+from typing import Optional
+
+
+class Progress:
+    """Display incremental progress on a single console line.
+
+    Parameters
+    ----------
+    label:
+        Description for the progress line, e.g. ``"Pulling APKs"``.
+    total:
+        Optional total count.  If provided the output will render as
+        ``"label: current/total"``.  When ``None`` only the current value is
+        displayed.
+    every:
+        Only update the console every ``every`` calls to :meth:`update`.
+    """
+
+    def __init__(self, label: str, total: Optional[int] = None, every: int = 1):
+        self.label = label
+        self.total = total
+        self.every = max(1, every)
+
+    def update(self, current: int, counters: Optional[Mapping[str, int]] = None) -> None:
+        """Render the ticker if the ``current`` count warrants an update."""
+
+        if current % self.every != 0 and (self.total is None or current != self.total):
+            return
+
+        parts = [f"{self.label}: {current}"]
+        if self.total is not None:
+            parts[0] += f"/{self.total}"
+
+        if counters:
+            extra = ", ".join(f"{v} {k}" for k, v in counters.items())
+            parts.append(f"({extra})")
+
+        sys.stdout.write("\r" + " ".join(parts))
+        sys.stdout.flush()
+
+        if self.total is not None and current >= self.total:
+            sys.stdout.write("\n")
+            sys.stdout.flush()


### PR DESCRIPTION
## Summary
- suppress missing-APK warnings unless verbose to reduce log noise
- allow adb runner to skip error logging, preventing repeated pull failures
- route APK pulls through the new silent mode for cleaner progress output
- parse multi-line `pm path` output to select the base APK and include uninstalled packages when listing APK paths
- scan APK contents for an expanded set of token patterns (AWS keys, JWTs, private key blocks, etc.) to surface likely secrets

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a787d13c588327bb0ead913458c495