### PR TITLE
feat: debug flag and configurable artifact display

### DIFF
--- a/analysis/static_analysis/package_analysis.py
+++ b/analysis/static_analysis/package_analysis.py
@@ -150,7 +150,7 @@ def verify_package_apks(
             log.debug(f"APK for {pkg} located at {path}")
         else:
             missing.append(pkg)
-            if _is_verbose():
+            if _is_debug_enabled():
                 log.warning(f"No APK path found for {pkg}")
         ticker.update(idx)
 
@@ -236,13 +236,13 @@ def analyze_packages(serial: str) -> List[PackageReport]:
     )
 
     if string_finder:
-        verbose = _is_verbose()
-        string_finder.print_failure_summary(verbose=verbose)
+        debug = _is_debug_enabled()
+        string_finder.print_failure_summary(debug=debug)
 
     return reports
 
 
-def _is_verbose() -> bool:
+def _is_debug_enabled() -> bool:
     """Check if console logging is at DEBUG level."""
 
     logger = logging.getLogger()

--- a/analysis/static_analysis/report_formatter.py
+++ b/analysis/static_analysis/report_formatter.py
@@ -1,0 +1,68 @@
+"""Formatting helpers for static analysis reports."""
+
+from collections import Counter
+from typing import Iterable, Optional
+
+from .package_analysis import PackageReport
+import utils.logging_utils.logging_engine as log
+
+
+def print_reports(
+    reports: Iterable[PackageReport],
+    serial: str,
+    artifact_limit: Optional[int] = 3,
+) -> None:
+    """Render package reports and summary to the console."""
+
+    reports = list(reports)
+    if not reports:
+        print(f"\n⚠️  No packages found on {serial}.")
+        return
+
+    print(f"\n📦 Installed Packages on {serial}")
+    print("----------------------------------")
+    for rep in reports[:20]:
+        risk_marker = "!" if rep.risk_score else ""
+        print(f" - {rep.name} [{rep.category}] {risk_marker}")
+        for perm in rep.dangerous_permissions[:5]:
+            print(f"     ⚠ {perm}")
+        if len(rep.dangerous_permissions) > 5:
+            print("     ...")
+
+        if rep.artifacts and artifact_limit != 0:
+            limit = None if artifact_limit is None else artifact_limit
+            shown = rep.artifacts if limit is None else rep.artifacts[:limit]
+            for art in shown:
+                print(f"     🔑 {art}")
+            if limit is not None and len(rep.artifacts) > limit:
+                remaining = len(rep.artifacts) - limit
+                print(f"     (+{remaining} more)")
+
+    flagged = [r for r in reports if r.risk_score]
+    category_counts = Counter(r.category for r in reports)
+
+    print("\nSummary")
+    print("-------")
+    print(f"Total packages: {len(reports)}")
+    print(f"Flagged apps : {len(flagged)}")
+    for cat, count in category_counts.items():
+        print(f" - {cat}: {count}")
+
+    if flagged:
+        print("\nFlagged applications:")
+        for rep in flagged:
+            perms = ", ".join(rep.dangerous_permissions)
+            print(
+                f" - {rep.name} [{rep.category}] risk={rep.risk_score} :: {perms}"
+            )
+            if rep.artifacts and artifact_limit != 0:
+                limit = None if artifact_limit is None else artifact_limit
+                arts = rep.artifacts if limit is None else rep.artifacts[:limit]
+                line = ", ".join(arts)
+                if limit is not None and len(rep.artifacts) > limit:
+                    remaining = len(rep.artifacts) - limit
+                    line += f", (+{remaining} more)"
+                print(f"     artifacts: {line}")
+
+    print()
+    log.info(f"Static analysis complete for {serial}")

--- a/analysis/static_analysis/string_finder.py
+++ b/analysis/static_analysis/string_finder.py
@@ -137,19 +137,19 @@ def find_artifacts(serial: str, package: str) -> List[str]:
     return sorted(artifacts)
 
 
-def print_failure_summary(verbose: bool = False) -> None:
+def print_failure_summary(debug: bool = False) -> None:
     """Print and reset collected failure information."""
 
     if not _failure_counts:
         return
 
-    print("\nFailure Summary")
-    print("---------------")
+    log.info("\nFailure Summary")
+    log.info("---------------")
     for reason, count in _failure_counts.items():
-        print(f" - {reason}: {count}")
-    if verbose and _failure_details:
+        log.info(f" - {reason}: {count}")
+    if debug and _failure_details:
         for detail in _failure_details:
-            print(f"   {detail}")
+            log.debug(f"   {detail}")
 
     _failure_counts.clear()
     _failure_details.clear()

--- a/config/app_config.py
+++ b/config/app_config.py
@@ -9,3 +9,8 @@ APP_GITHUB_REPO: str = "None"
 # Default color theme palette. Can be overridden via the GF_THEME env var or
 # the ``--theme`` runtime flag processed in ``main.py``.
 THEME_PALETTE: str = os.getenv("GF_THEME", "cyber")
+
+# Maximum number of artifacts (tokens/strings) to display per package during
+# static analysis output. ``None`` shows all artifacts, while ``0`` suppresses
+# artifact display entirely.
+ARTIFACT_LIMIT: int | None = 3

--- a/device/device_menu.py
+++ b/device/device_menu.py
@@ -9,6 +9,7 @@ from device import vendor_normalizer
 from utils.display_utils import prompt_utils, menu_utils
 from utils.display_utils.menu_utils import MenuExit
 from analysis.static_analysis import run_static_analysis   # <-- import
+from config import app_config
 import utils.logging_utils.logging_engine as log
 
 
@@ -53,7 +54,8 @@ def interactive_device_menu(device: DeviceInfo):
         print("\n🔍 Running static analysis...\n")
         try:
             log.info(f"Launching static analysis for {serial}")
-            run_static_analysis.analyze_device(serial)   # <-- call into analysis
+            limit = getattr(app_config, "ARTIFACT_LIMIT", 3)
+            run_static_analysis.analyze_device(serial, artifact_limit=limit)
             log.info(f"Static analysis finished for {serial}")
         except KeyboardInterrupt:
             print("\n⚠️  Static analysis interrupted. Returning to menu.\n")

--- a/main.py
+++ b/main.py
@@ -63,9 +63,21 @@ def main():
         help="Color theme to use (overrides config default)",
     )
     parser.add_argument(
+        "--debug",
         "--verbose",
+        dest="debug",
         action="store_true",
         help="Enable debug logging to console",
+    )
+    parser.add_argument(
+        "--artifacts",
+        default="3",
+        help="Number of artifacts per package to display, or 'all'",
+    )
+    parser.add_argument(
+        "--no-artifacts",
+        action="store_true",
+        help="Suppress artifact display in analysis output",
     )
     args = parser.parse_args()
 
@@ -78,8 +90,8 @@ def main():
         except Exception as e:
             log.warning(f"Failed to set theme '{selected_palette}': {e}")
 
-    # Optional verbose console logging (only if supported by logging engine)
-    if args.verbose:
+    # Optional debug console logging (only if supported by logging engine)
+    if args.debug:
         if hasattr(log, "set_console_level"):
             try:
                 log.set_console_level(logging.DEBUG)
@@ -89,7 +101,15 @@ def main():
                     log.set_console_level("DEBUG")  # type: ignore[arg-type]
                 except Exception:
                     pass
-        log.info("Verbose console logging enabled")
+        log.info("Debug console logging enabled")
+
+    # Configure artifact display limit
+    artifact_arg = getattr(args, "artifacts", "3")
+    if args.no_artifacts:
+        limit: int | None = 0
+    else:
+        limit = None if str(artifact_arg).lower() == "all" else int(artifact_arg)
+    setattr(app_config, "ARTIFACT_LIMIT", limit)
 
     # Trap Ctrl+C
     signal.signal(signal.SIGINT, handle_interrupt)

--- a/utils/adb_utils/adb_runner.py
+++ b/utils/adb_utils/adb_runner.py
@@ -44,7 +44,8 @@ def execute_command(
             timeout=timeout,
         )
         output = result.stdout.strip()
-        log.debug(f"[EXECUTE] Output: {output[:200]}...")
+        snippet = output if len(output) <= 200 else f"{output[:200]}..."
+        log.debug(f"[EXECUTE] Output: {snippet}")
         return {"success": True, "output": output, "error": ""}
 
     except subprocess.TimeoutExpired:

--- a/utils/logging_utils/logging_core.py
+++ b/utils/logging_utils/logging_core.py
@@ -22,6 +22,8 @@ class LoggingCore:
         # configure root logger
         self.logger = logging.getLogger()
         self.logger.setLevel(logging.DEBUG)
+        # avoid duplicate handlers if re-initialized
+        self.logger.handlers.clear()
 
         # formatter for logs
         formatter = logging.Formatter(


### PR DESCRIPTION
## Summary
- add `--debug` flag to enable debug logging on console
- make artifact output limit configurable via CLI and config
- split static analysis report formatting into dedicated helper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a78545c8bc83278975c8ae26fd0390