### PR TITLE
Add DEX feature extraction and fingerprinting

### DIFF
--- a/analysis/dex_features/__init__.py
+++ b/analysis/dex_features/__init__.py
@@ -1,0 +1,6 @@
+"""DEX feature extraction utilities."""
+
+from .dex_parser import parse_dex_features
+from .schema import DexFeatureSchema
+
+__all__ = ["parse_dex_features", "DexFeatureSchema"]

--- a/analysis/dex_features/dex_parser.py
+++ b/analysis/dex_features/dex_parser.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from androguard.core.dex import DEX
+
+from .fingerprinting import fingerprint_dex
+from .schema import DexFeatureSchema
+
+
+REFLECTION_MARKERS = (
+    "java/lang/reflect",  # Generic reflection package
+    "Class.forName",      # Dynamic class loading
+    "getMethod",          # Method lookup
+    "invoke",             # java.lang.reflect.Method#invoke
+)
+
+
+def parse_dex_features(path: str) -> DexFeatureSchema:
+    """Parse *path* and return :class:`DexFeatureSchema`.
+
+    Parameters
+    ----------
+    path:
+        Path to a ``classes.dex`` file.
+    """
+
+    with open(path, "rb") as fp:
+        dex = DEX(fp.read())
+
+    classes = dex.get_classes()
+    methods = dex.get_methods()
+    strings = dex.get_strings()
+
+    class_count = len(classes)
+    method_count = len(methods)
+
+    string_hits = any(any(marker in s for marker in REFLECTION_MARKERS) for s in strings)
+    method_hits = any(
+        any(marker in (m.get_name() or "") for marker in REFLECTION_MARKERS) for m in methods
+    )
+    uses_reflection = string_hits or method_hits
+
+    libraries = fingerprint_dex(path)
+    return DexFeatureSchema(
+        class_count=class_count,
+        method_count=method_count,
+        uses_reflection=uses_reflection,
+        libraries=libraries,
+    )

--- a/analysis/dex_features/fingerprinting.py
+++ b/analysis/dex_features/fingerprinting.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Dict, List
+
+# Simple fingerprint database. Real deployments would likely load this from a
+# remote feed or a configuration file.  The default entry is populated for the
+# unit tests and represents the embedded DEX sample used there.
+KNOWN_LIB_HASHES: Dict[str, str] = {
+    # sha256: library name
+    "ef17a9de095d3f5c0fce95ee78cfba455e43502c2cc3517ca0799b562f5ab2c3": "hello-lib",
+}
+
+
+def fingerprint_dex(path: str) -> List[str]:
+    """Return names of known libraries detected in *path*.
+
+    The detection is based on a SHA-256 hash of the DEX contents.  The hash is
+    looked up in :data:`KNOWN_LIB_HASHES`.
+    """
+
+    with open(path, "rb") as fp:
+        digest = hashlib.sha256(fp.read()).hexdigest()
+    return [name for hash_, name in KNOWN_LIB_HASHES.items() if hash_ == digest]

--- a/analysis/dex_features/schema.py
+++ b/analysis/dex_features/schema.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class DexFeatureSchema:
+    """Schema describing extracted DEX features.
+
+    Attributes
+    ----------
+    class_count:
+        Number of classes defined in the DEX file.
+    method_count:
+        Number of methods declared in the DEX file.
+    uses_reflection:
+        True when reflection APIs are referenced by the application.
+    libraries:
+        List of known third-party libraries detected via fingerprinting.
+    """
+
+    class_count: int
+    method_count: int
+    uses_reflection: bool
+    libraries: List[str] = field(default_factory=list)

--- a/logs/android_tool.log
+++ b/logs/android_tool.log
@@ -3683,3 +3683,43 @@ package:/apex/com.android.appsearch/priv-app/com.google.android.appsearch.apk@36
 2025-08-21 16:13:50 | INFO | root | ADB shell opened for ZY22JK89DR
 2025-08-21 16:13:52 | INFO | root | Exiting device menu for ZY22JK89DR
 2025-08-21 16:13:52 | INFO | root | Application exited cleanly
+2025-08-21 22:50:44 | DEBUG | root | Fetching full package dump for ABC123
+2025-08-21 22:50:44 | INFO | root | Parsed permissions for 2 packages in total
+2025-08-21 22:50:44 | DEBUG | root | Listing APK paths for ABC123
+2025-08-21 22:50:44 | INFO | root | Discovered APK paths for 1 packages on ABC123
+2025-08-21 22:50:44 | INFO | root | Validating APK paths for 2 packages
+2025-08-21 22:50:44 | DEBUG | root | APK for com.example.one located at /data/app/com.example.one-1/base.apk
+2025-08-21 22:50:44 | INFO | root | Skipping 1 packages without APKs
+2025-08-21 22:50:44 | INFO | root | Computing hashes for 1 packages
+2025-08-21 22:50:44 | DEBUG | root | Hash for com.example.one: hashone
+2025-08-21 22:50:44 | INFO | root | Analyzing 1 packages on ABC123
+2025-08-21 22:50:44 | INFO | root | Generated 1 package reports for ABC123; flagged 1 at-risk apps
+2025-08-21 22:50:44 | DEBUG | root | Fetching full package dump for ABC123
+2025-08-21 22:50:44 | WARNING | root | No package data found for ABC123
+2025-08-21 22:50:44 | DEBUG | root | Listing APK paths for ABC123
+2025-08-21 22:50:44 | WARNING | root | No APK paths found for ABC123
+2025-08-21 22:50:44 | INFO | root | Validating APK paths for 0 packages
+2025-08-21 22:50:44 | INFO | root | Computing hashes for 0 packages
+2025-08-21 22:50:44 | INFO | root | Analyzing 0 packages on ABC123
+2025-08-21 22:50:44 | INFO | root | Generated 0 package reports for ABC123; flagged 0 at-risk apps
+2025-08-21 22:50:44 | DEBUG | root | Fetching full package dump for ABC123
+2025-08-21 22:50:44 | INFO | root | Parsed permissions for 2 packages in total
+2025-08-21 22:50:44 | DEBUG | root | Listing APK paths for ABC123
+2025-08-21 22:50:44 | INFO | root | Discovered APK paths for 2 packages on ABC123
+2025-08-21 22:50:44 | INFO | root | Validating APK paths for 2 packages
+2025-08-21 22:50:44 | DEBUG | root | APK for com.example.one located at /data/app/com.example.one-1/base.apk
+2025-08-21 22:50:44 | DEBUG | root | APK for com.example.two located at /data/app/com.example.two-1/base.apk
+2025-08-21 22:50:44 | INFO | root | Computing hashes for 2 packages
+2025-08-21 22:50:44 | DEBUG | root | Hash for com.example.one: hashone
+2025-08-21 22:50:44 | DEBUG | root | Hash for com.example.two: hashtwo
+2025-08-21 22:50:44 | INFO | root | Analyzing 2 packages on ABC123
+2025-08-21 22:50:44 | INFO | root | Generated 2 package reports for ABC123; flagged 2 at-risk apps
+2025-08-21 22:50:44 | DEBUG | root | Device 1: {'index': 1, 'serial': 'ABC123', 'type': 'Physical', 'vendor': 'Google', 'model': 'Pixel 4', 'state': 'device', 'ip': '1.2.3.4'}
+2025-08-21 22:50:44 | DEBUG | root | Device 2: {'index': 2, 'serial': 'XYZ789', 'type': 'Physical', 'vendor': 'Lg', 'model': 'Nexus 5', 'state': 'offline', 'ip': '1.2.3.4'}
+2025-08-21 22:50:44 | DEBUG | root | Device 1: {'index': 1, 'serial': 'ABC123', 'type': 'Physical', 'vendor': 'Google', 'model': 'Pixel 4', 'state': 'device', 'ip': '1.2.3.4'}
+2025-08-21 22:50:44 | DEBUG | root | Device 2: {'index': 2, 'serial': 'XYZ789', 'type': 'Physical', 'vendor': 'Lg', 'model': 'Nexus 5', 'state': 'offline', 'ip': '1.2.3.4'}
+2025-08-21 22:50:44 | DEBUG | root | Device 1: {'index': 1, 'serial': 'ABC123', 'type': 'Physical', 'vendor': 'Google', 'model': 'Pixel 4', 'state': 'device', 'ip': '1.2.3.4'}
+2025-08-21 22:50:44 | DEBUG | root | Device 2: {'index': 2, 'serial': 'XYZ789', 'type': 'Physical', 'vendor': 'Lg', 'model': 'Nexus 5', 'state': 'offline', 'ip': '1.2.3.4'}
+2025-08-21 22:50:44 | DEBUG | root | Device 1: {'index': 1, 'serial': 'ABC123', 'type': 'Physical', 'vendor': 'Google', 'model': 'Pixel 4', 'state': 'device', 'ip': '1.2.3.4'}
+2025-08-21 22:50:44 | DEBUG | root | Device 2: {'index': 2, 'serial': 'XYZ789', 'type': 'Physical', 'vendor': 'Lg', 'model': 'Nexus 5', 'state': 'offline', 'ip': '1.2.3.4'}
+2025-08-21 22:50:44 | WARNING | root | IP lookup failed for ABC123: boom

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+androguard==4.1.3

--- a/tests/test_dex_features.py
+++ b/tests/test_dex_features.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from analysis.dex_features import parse_dex_features
+from analysis.dex_features.fingerprinting import fingerprint_dex
+
+
+# Base64 representation of a minimal DEX file used for tests.  The data was
+# previously stored as ``tests/hello.dex`` but is now embedded here to avoid
+# shipping binary artifacts in the repository.
+HELLO_DEX_B64 = (
+    "ZGV4CjAzNQA6XhkMZcwIftV2X0TCAHQjQQ4EO8A1Q1PsAgAAcAAAAHhWNBIAAAAAAAAAAEwCAA"
+    "AOAAAAcAAAAAcAAACoAAAAAwAAAMQAAAABAAAA6AAAAAQAAADwAAAAAQAAABABAAC8AQAAMAEAA"
+    "HYBAAB+AQAAjQEAAJ4BAACsAQAAwwEAANcBAADrAQAA/wEAAAICAAAGAgAAGwIAACECAAAmAgAA"
+    "AwAAAAQAAAAFAAAABgAAAAcAAAAIAAAACgAAAAgAAAAFAAAAAAAAAAkAAAAFAAAAaAEAAAkAAAAF"
+    "AAAAcAEAAAQAAQAMAAAAAAAAAAAAAAAAAAIACwAAAAEAAQANAAAAAgAAAAAAAAAAAAAAAAAAAAIA"
+    "AAAAAAAAAgAAAAAAAAA7AgAAAAAAAAEAAQABAAAALwIAAAQAAABwEAMAAAAOAAMAAQACAAAANAIA"
+    "AAgAAABiAAAAGgEBAG4gAgAQAA4AAQAAAAMAAAABAAAABgAGPGluaXQ+AA1IZWxsbywgV29ybGQh"
+    "AA9IZWxsb1dvcmxkLmphdmEADExIZWxsb1dvcmxkOwAVTGphdmEvaW8vUHJpbnRTdHJlYW07ABJM"
+    "amF2YS9sYW5nL09iamVjdDsAEkxqYXZhL2xhbmcvU3RyaW5nOwASTGphdmEvbGFuZy9TeXN0ZW07"
+    "AAFWAAJWTAATW0xqYXZhL2xhbmcvU3RyaW5nOwAEbWFpbgADb3V0AAdwcmludGxuAAEABw4AAwEA"
+    "Bw54AAAAAgAAgIAEsAIBCcgCAAAADQAAAAAAAAABAAAAAAAAAAEAAAAOAAAAcAAAAAIAAAAHAAAA"
+    "qAAAAAMAAAADAAAAxAAAAAQAAAABAAAA6AAAAAUAAAAEAAAA8AAAAAYAAAABAAAAEAEAAAEgAAAC"
+    "AAAAMAEAAAEQAAACAAAAaAEAAAIgAAAOAAAAdgEAAAMgAAACAAAALwIAAAAgAAABAAAAOwIAAAAQ"
+    "AAABAAAATAIAAA=="
+)
+
+
+@pytest.fixture()
+def hello_dex(tmp_path):
+    """Write the embedded DEX to a temporary path and return the filename."""
+
+    data = base64.b64decode(HELLO_DEX_B64)
+    path = tmp_path / "hello.dex"
+    path.write_bytes(data)
+    return str(path)
+
+
+def test_parse_dex_features_counts_and_reflection(hello_dex):
+    features = parse_dex_features(hello_dex)
+    assert features.class_count == 1
+    assert features.method_count == 4
+    assert features.uses_reflection is False
+    assert features.libraries == ["hello-lib"]
+
+
+def test_fingerprint_dex_matches_known_hash(hello_dex):
+    libs = fingerprint_dex(hello_dex)
+    assert libs == ["hello-lib"]


### PR DESCRIPTION
## Summary
- add feature schema and parser for class counts and reflection detection
- implement SHA-256 based library fingerprinting
- record method count in DEX features for richer metrics
- embed DEX sample directly in tests to avoid binary artifacts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a79a23f70c8327835f0a679f99246e