### PR TITLE
Add social app finder utilities

### DIFF
--- a/analysis/static_analysis/app_categories.py
+++ b/analysis/static_analysis/app_categories.py
@@ -3,19 +3,75 @@
 # These mappings are placeholders and can be replaced with a database-driven
 # approach in the future.
 KNOWN_APPS = {
+    # Social media platforms
     "com.facebook.katana": "Social Media",
+    "com.facebook.lite": "Social Media",
     "com.instagram.android": "Social Media",
     "com.snapchat.android": "Social Media",
     "com.twitter.android": "Social Media",
     "com.tiktok.android": "Social Media",
+    "com.zhiliaoapp.musically": "Social Media",
+    "com.ss.android.ugc.trill": "Social Media",
+    "com.ss.android.ugc.aweme": "Social Media",
+    "com.ss.android.ugc.aweme.lite": "Social Media",
+    "com.zhiliaoapp.musically.go": "Social Media",
+    "com.reddit.frontpage": "Social Media",
+    "com.vkontakte.android": "Social Media",
+    "com.pinterest": "Social Media",
+    "com.linkedin.android": "Social Media",
+
+    # Messaging platforms
     "com.whatsapp": "Messaging",
+    "com.whatsapp.w4b": "Messaging",
     "com.facebook.orca": "Messaging",
     "org.telegram.messenger": "Messaging",
+    "com.discord": "Messaging",
+    "com.tencent.mm": "Messaging",
+    "org.thoughtcrime.securesms": "Messaging",
+    "jp.naver.line.android": "Messaging",
+
+    # Financial apps (examples)
     "com.bankofamerica.mobilebanking": "Financial",
     "com.chase.sig.android": "Financial",
 }
 
 DEFAULT_CATEGORY = "Other"
+
+# Human-friendly labels for select social and messaging packages.  This map is
+# referenced by :mod:`social_app_finder` to keep the list of curated social apps
+# in a single location.
+SOCIAL_APP_LABELS = {
+    # TikTok and variants
+    "com.zhiliaoapp.musically": "TikTok",
+    "com.ss.android.ugc.trill": "TikTok",
+    "com.ss.android.ugc.aweme": "TikTok",
+    "com.ss.android.ugc.aweme.lite": "TikTok Lite",
+    "com.zhiliaoapp.musically.go": "TikTok Lite",
+    "com.tiktok.android": "TikTok",
+
+    # Meta/Facebook ecosystem
+    "com.instagram.android": "Instagram",
+    "com.facebook.katana": "Facebook",
+    "com.facebook.lite": "Facebook Lite",
+    "com.facebook.orca": "Messenger",
+
+    # Messaging platforms
+    "com.whatsapp": "WhatsApp",
+    "com.whatsapp.w4b": "WhatsApp Business",
+    "org.telegram.messenger": "Telegram",
+    "com.discord": "Discord",
+    "com.tencent.mm": "WeChat",
+    "org.thoughtcrime.securesms": "Signal",
+    "jp.naver.line.android": "LINE",
+
+    # Other social platforms
+    "com.snapchat.android": "Snapchat",
+    "com.twitter.android": "Twitter",
+    "com.reddit.frontpage": "Reddit",
+    "com.vkontakte.android": "VK",
+    "com.pinterest": "Pinterest",
+    "com.linkedin.android": "LinkedIn",
+}
 
 
 def get_category(package: str) -> str:

--- a/analysis/static_analysis/social_app_finder.py
+++ b/analysis/static_analysis/social_app_finder.py
@@ -1,0 +1,119 @@
+"""Identify installed social media applications via ADB.
+
+This module provides helpers to list third-party packages on a connected
+Android device and flag any packages that match a curated list of social
+media or messaging applications. For each match, basic metadata can be
+retrieved via ``dumpsys package``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+import utils.logging_utils.logging_engine as log
+from utils.adb_utils.adb_runner import run_adb_command
+# Curated social app package -> label mapping lives in app_categories.
+from .app_categories import SOCIAL_APP_LABELS as SOCIAL_APPS
+
+
+@dataclass
+class SocialApp:
+    """Information collected about a detected social application."""
+
+    package: str
+    app_name: str
+    apk_paths: List[str]
+    label: Optional[str]
+    metadata: Dict[str, str]
+
+
+def _parse_package_listing(output: str) -> Dict[str, str]:
+    """Parse ``pm list packages -f`` output into ``{package: path}`` mapping."""
+    packages: Dict[str, str] = {}
+    for line in output.splitlines():
+        line = line.strip()
+        if not line.startswith("package:"):
+            continue
+        path_pkg = line[len("package:") :]
+        path, _, pkg = path_pkg.partition("=")
+        if pkg:
+            packages[pkg.strip()] = path.strip()
+    return packages
+
+
+def get_third_party_packages(serial: str) -> Dict[str, str]:
+    """Return mapping of installed third-party packages to their APK path."""
+    result = run_adb_command(serial, ["shell", "pm", "list", "packages", "-f", "-3"])
+    if not result.get("success", False):
+        log.warning(
+            f"ADB failed while listing packages for {serial} :: {result.get('error', '')}"
+        )
+        return {}
+
+    output = result.get("output") or ""
+    return _parse_package_listing(str(output))
+
+
+def get_apk_paths(serial: str, package: str) -> List[str]:
+    """Return all APK paths for ``package`` using ``pm path``."""
+    result = run_adb_command(serial, ["shell", "pm", "path", package])
+    if not result.get("success", False):
+        log.debug(f"Failed to resolve APK path for {package}: {result.get('error', '')}")
+        return []
+
+    paths: List[str] = []
+    output = result.get("output") or ""
+    for line in str(output).splitlines():
+        line = line.strip()
+        if line.startswith("package:"):
+            paths.append(line[len("package:") :])
+    return paths
+
+
+def get_app_info(serial: str, package: str) -> tuple[Optional[str], Dict[str, str]]:
+    """Return application label and basic metadata for ``package``."""
+    result = run_adb_command(serial, ["shell", "dumpsys", "package", package])
+    if not result.get("success", False):
+        log.debug(f"Failed to dumpsys {package}: {result.get('error', '')}")
+        return None, {}
+
+    label: Optional[str] = None
+    meta: Dict[str, str] = {}
+    output = str(result.get("output") or "")
+    for raw in output.splitlines():
+        line = raw.strip()
+        if line.startswith("application-label:"):
+            label = line.split(":", 1)[1].strip()
+        elif any(
+            line.startswith(prefix)
+            for prefix in (
+                "versionName=",
+                "versionCode=",
+                "installerPackageName=",
+                "uid=",
+            )
+        ):
+            key, _, value = line.partition("=")
+            meta[key] = value.strip()
+    return label, meta
+
+
+def find_social_apps(serial: str) -> List[SocialApp]:
+    """Identify installed social apps on the device identified by ``serial``."""
+    packages = get_third_party_packages(serial)
+    found: List[SocialApp] = []
+    for pkg in packages:
+        if pkg not in SOCIAL_APPS:
+            continue
+        apk_paths = get_apk_paths(serial, pkg)
+        label, meta = get_app_info(serial, pkg)
+        found.append(
+            SocialApp(
+                package=pkg,
+                app_name=SOCIAL_APPS[pkg],
+                apk_paths=apk_paths,
+                label=label,
+                metadata=meta,
+            )
+        )
+    return found

--- a/tests/test_social_app_finder.py
+++ b/tests/test_social_app_finder.py
@@ -1,0 +1,68 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from analysis.static_analysis import social_app_finder as saf
+
+
+def test_parse_package_listing():
+    sample = (
+        "package:/data/app/abc/base.apk=com.zhiliaoapp.musically\n"
+        "package:/data/app/def/base.apk=com.random.app\n"
+        "package:/data/app/ghi/base.apk=com.instagram.android\n"
+    )
+    parsed = saf._parse_package_listing(sample)
+    assert parsed["com.zhiliaoapp.musically"] == "/data/app/abc/base.apk"
+    assert parsed["com.instagram.android"] == "/data/app/ghi/base.apk"
+    assert "com.random.app" in parsed
+
+
+def test_find_social_apps(monkeypatch):
+    # Prepare fake adb responses
+    def fake_run(serial, args, **kwargs):
+        if args == ["shell", "pm", "list", "packages", "-f", "-3"]:
+            output = (
+                "package:/data/app/a/base.apk=com.zhiliaoapp.musically\n"
+                "package:/data/app/b/base.apk=com.instagram.android\n"
+                "package:/data/app/c/base.apk=com.other.app\n"
+            )
+            return {"success": True, "output": output}
+        if args == ["shell", "pm", "path", "com.zhiliaoapp.musically"]:
+            return {"success": True, "output": "package:/data/app/a/base.apk"}
+        if args == ["shell", "pm", "path", "com.instagram.android"]:
+            return {"success": True, "output": "package:/data/app/b/base.apk"}
+        if args == ["shell", "dumpsys", "package", "com.zhiliaoapp.musically"]:
+            return {
+                "success": True,
+                "output": (
+                    "application-label: TikTok\n"
+                    "versionName=1.2.3\nversionCode=123\n"
+                    "installerPackageName=com.android.vending\nuid=1001"
+                ),
+            }
+        if args == ["shell", "dumpsys", "package", "com.instagram.android"]:
+            return {
+                "success": True,
+                "output": (
+                    "application-label: Instagram\n"
+                    "versionName=9.9.9\nversionCode=999\n"
+                    "installerPackageName=com.android.vending\nuid=2002"
+                ),
+            }
+        return {"success": False, "output": "", "error": "unexpected command"}
+
+    monkeypatch.setattr(saf, "run_adb_command", fake_run)
+
+    apps = saf.find_social_apps("SERIAL")
+    assert {app.package for app in apps} == {
+        "com.zhiliaoapp.musically",
+        "com.instagram.android",
+    }
+    tiktok = next(a for a in apps if a.package == "com.zhiliaoapp.musically")
+    assert tiktok.app_name == "TikTok"
+    assert tiktok.label == "TikTok"
+    assert tiktok.metadata["versionName"] == "1.2.3"
+    assert "uid" in tiktok.metadata


### PR DESCRIPTION
## Summary
- centralize social/messaging app labels in `app_categories` for easier maintenance
- refactor `social_app_finder` to load curated mapping from the shared list
- tidy social app finder tests

## Testing
- `pip show androguard | head -n 20`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7cdee01f48327ab5c53c74b556594