### PR TITLE
Add database menu placeholder

### DIFF
--- a/database/db_menu.py
+++ b/database/db_menu.py
@@ -1,1 +1,6 @@
-# db_menu.py
+"""Database menu placeholder module."""
+
+def db_menu() -> None:
+    """Display a placeholder message for the database menu."""
+    print("\n[TODO] Database Menu\n")
+

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from utils.display_utils import menu_utils, error_utils, theme
 import utils.logging_utils.logging_engine as log
 from device import show_devices, connect_to_device
 from utils.about_app import about_app
+from database.db_menu import db_menu
 
 
 # ---------- Menu Actions ----------
@@ -38,8 +39,8 @@ def action_connect_to_device():
 def action_database_menu():
     """Action: Database menu placeholder."""
     log.info("Opened Database Menu")
-    # TODO: Hook into actual DB logic once implemented
-    print("\n[TODO] Database Menu\n")
+    # Delegate to database menu placeholder
+    db_menu()
 
 
 # ---------- Signal Handling ----------


### PR DESCRIPTION
## Summary
- stub out a `db_menu` function that prints a TODO message
- hook the main CLI's database option to call the placeholder

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7e88dd0e88327aae50a10654d4586