### PR TITLE
Add placeholder dynamic analysis function

### DIFF
--- a/analysis/dynamic_analysis/run_dynamic_analysis.py
+++ b/analysis/dynamic_analysis/run_dynamic_analysis.py
@@ -1,0 +1,11 @@
+"""Placeholder dynamic analysis implementation."""
+
+
+
+def run_dynamic_analysis(serial: str) -> None:
+    """Placeholder dynamic analysis for a device.
+
+    Args:
+        serial: The device serial identifier.
+    """
+    print(f"Dynamic analysis not yet implemented for {serial}")

--- a/tests/test_run_dynamic_analysis.py
+++ b/tests/test_run_dynamic_analysis.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from analysis.dynamic_analysis.run_dynamic_analysis import run_dynamic_analysis
+
+
+def test_run_dynamic_analysis_placeholder(capsys):
+    run_dynamic_analysis("serial123")
+    out = capsys.readouterr().out.strip()
+    assert out == "Dynamic analysis not yet implemented for serial123"


### PR DESCRIPTION
## Summary
- stub out dynamic analysis with a placeholder function that prints a not-implemented message
- add unit test to ensure the placeholder message is emitted

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7e887259083279868e5a082bec011