### PR TITLE
Normalize permissions and declare MySQL dependency

### DIFF
--- a/analysis/static_analysis/apk_analysis.py
+++ b/analysis/static_analysis/apk_analysis.py
@@ -27,6 +27,8 @@ def analyze_apk(apk_path: str) -> Dict[str, str]:
         return {}
 
     metadata: Dict[str, str] = {}
+    permissions: list[str] = []
+
     for line in output.splitlines():
         if line.startswith("package:"):
             for part in line.split():
@@ -36,6 +38,9 @@ def analyze_apk(apk_path: str) -> Dict[str, str]:
         elif line.startswith("application-label:"):
             metadata["label"] = line.split(":", 1)[1].strip("'")
         elif line.startswith("uses-permission:"):
-            metadata.setdefault("permissions", "")
-            metadata["permissions"] += line.split(":", 1)[1].strip("'") + ", "
+            permissions.append(line.split(":", 1)[1].strip("'"))
+
+    if permissions:
+        metadata["permissions"] = ", ".join(permissions)
+
     return metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 androguard==4.1.3
+mysql-connector-python>=8.0


### PR DESCRIPTION
## Summary
- avoid trailing commas in APK permission metadata by collecting permission strings and joining them
- declare MySQL connector dependency in `requirements.txt`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7e5ec4e108327b40991ed1009466f