### PR TITLE
Normalize permissions and declare MySQL dependency

### DIFF
--- a/analysis/dynamic_analysis/run_dynamic_analysis.py
+++ b/analysis/dynamic_analysis/run_dynamic_analysis.py
@@ -1,5 +1,6 @@
 """Placeholder dynamic analysis implementation."""
 
+import utils.logging_utils.logging_engine as log
 
 
 def run_dynamic_analysis(serial: str) -> None:
@@ -8,4 +9,7 @@ def run_dynamic_analysis(serial: str) -> None:
     Args:
         serial: The device serial identifier.
     """
-    print(f"Dynamic analysis not yet implemented for {serial}")
+    message = f"Dynamic analysis not yet implemented for {serial}"
+    log.warning(message)
+    print(message)
+

--- a/analysis/static_analysis/apk_analysis.py
+++ b/analysis/static_analysis/apk_analysis.py
@@ -27,6 +27,8 @@ def analyze_apk(apk_path: str) -> Dict[str, str]:
         return {}
 
     metadata: Dict[str, str] = {}
+    permissions: list[str] = []
+
     for line in output.splitlines():
         if line.startswith("package:"):
             for part in line.split():
@@ -36,6 +38,10 @@ def analyze_apk(apk_path: str) -> Dict[str, str]:
         elif line.startswith("application-label:"):
             metadata["label"] = line.split(":", 1)[1].strip("'")
         elif line.startswith("uses-permission:"):
-            metadata.setdefault("permissions", "")
-            metadata["permissions"] += line.split(":", 1)[1].strip("'") + ", "
+            permissions.append(line.split(":", 1)[1].strip("'"))
+
+    if permissions:
+        metadata["permissions"] = ", ".join(permissions)
+
     return metadata
+

--- a/device/vendor_normalizer.py
+++ b/device/vendor_normalizer.py
@@ -42,3 +42,4 @@ def normalize_vendor(details: Dict[str, str]) -> str:
 
     # ✅ Fallback
     return "Unknown"
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 androguard==4.1.3
+mysql-connector-python>=8.0


### PR DESCRIPTION
## Summary
- warn via logger when dynamic analysis is not implemented
- add missing trailing newlines for vendor normalization and APK analysis modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7e5ec4e108327b40991ed1009466f