### PR TITLE
Safely sort menu options with mixed keys

### DIFF
--- a/tests/test_menu_render.py
+++ b/tests/test_menu_render.py
@@ -49,3 +49,19 @@ def test_highlight_accent_style(capsys):
     )
     out = capsys.readouterr().out
     assert theme.color("fg.accent") in out
+
+
+def test_numeric_key_sorting(capsys):
+    options = {"10": ("Ten", dummy), "2": ("Two", dummy)}
+    menu_utils.print_menu_options(options, "Exit")
+    plain = strip_ansi(capsys.readouterr().out)
+    lines = [line.strip() for line in plain.splitlines() if line.strip()]
+    assert lines[:2] == ["[2] Two", "[10] Ten"]
+
+
+def test_non_numeric_key_sorting(capsys):
+    options = {"b": ("Bravo", dummy), "a": ("Alpha", dummy)}
+    menu_utils.print_menu_options(options, "Exit")
+    plain = strip_ansi(capsys.readouterr().out)
+    lines = [line.strip() for line in plain.splitlines() if line.strip()]
+    assert lines[:2] == ["[a] Alpha", "[b] Bravo"]

--- a/utils/display_utils/menu_utils.py
+++ b/utils/display_utils/menu_utils.py
@@ -32,7 +32,10 @@ def print_menu_options(
     """Render all menu options in sorted order.
 
     Args:
-        options: Mapping of option keys to (label, callable).
+        options: Mapping of option keys to (label, callable). Keys are strings
+            such as "1", "A", etc. Keys comprised solely of digits are sorted
+            numerically; all other keys fall back to lexical (alphabetical)
+            ordering. Mixing numeric and non-numeric keys is supported.
         exit_label: Text for the exit option.
         highlight: Option key to visually emphasize.
         highlight_style: Style token for highlighting (inverse, bold, accent).
@@ -45,7 +48,11 @@ def print_menu_options(
         "accent": theme.style("fg.accent", "bold"),
     }
     style_fn = styles.get(highlight_style, styles["inverse"])
-    for key in sorted(options.keys(), key=lambda x: int(x)):
+
+    def sort_key(k: str):
+        return (0, int(k)) if k.isdigit() else (1, k)
+
+    for key in sorted(options.keys(), key=sort_key):
         label, _ = options[key]
         hot = num_style(f"[{key}]")
         if highlight == key:


### PR DESCRIPTION
## Summary
- Document numeric and text key handling in `print_menu_options`
- Sort menu keys numerically when possible, otherwise lexically
- Test numeric and non-numeric menu option ordering

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7f54a706c832792b579de1311bd91