### PR TITLE
Add dynamic analysis log capture and tests

### DIFF
--- a/analysis/dynamic_analysis/run_dynamic_analysis.py
+++ b/analysis/dynamic_analysis/run_dynamic_analysis.py
@@ -1,15 +1,70 @@
-"""Placeholder dynamic analysis implementation."""
+"""Basic dynamic analysis implementation.
+
+This module provides a very small subset of dynamic analysis features. It is
+designed to run lightweight runtime checks against a connected Android device
+using ``adb``.  At the moment it gathers a snapshot of ``logcat`` output and the
+current activity stack and stores those results on disk.
+"""
+
+from pathlib import Path
+from typing import Optional, Union
 
 import utils.logging_utils.logging_engine as log
+from utils.adb_utils.adb_runner import run_adb_command
 
 
-def run_dynamic_analysis(serial: str) -> None:
-    """Placeholder dynamic analysis for a device.
+def run_dynamic_analysis(
+    serial: str,
+    output_dir: Optional[Union[str, Path]] = None,
+    duration: int = 15,
+) -> dict[str, Path]:
+    """Run simple dynamic analysis for a given device.
 
     Args:
         serial: The device serial identifier.
+        output_dir: Directory where analysis artefacts are written.  If not
+            provided ``dynamic_analysis`` will be created relative to the
+            current working directory.
+        duration: Maximum number of seconds to allow each adb command to run.
+
+    Returns:
+        Mapping of artefact names to the paths where they were written.
     """
-    message = f"Dynamic analysis not yet implemented for {serial}"
-    log.warning(message)
+
+    out_dir = Path(output_dir) if output_dir else Path("dynamic_analysis")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    logcat_path = out_dir / "logcat.txt"
+    activity_path = out_dir / "activity.txt"
+
+    # Capture a snapshot of logcat
+    logcat_res = run_adb_command(
+        serial, ["logcat", "-d"], timeout=duration, log_errors=False
+    )
+    if logcat_res["success"]:
+        logcat_path.write_text(logcat_res["output"])
+    else:
+        log.warning(logcat_res["error"])
+        logcat_path.write_text("")
+
+    # Capture the current activity stack
+    activity_res = run_adb_command(
+        serial,
+        ["shell", "dumpsys", "activity", "activities"],
+        timeout=duration,
+        log_errors=False,
+    )
+    if activity_res["success"]:
+        activity_path.write_text(activity_res["output"])
+    else:
+        log.warning(activity_res["error"])
+        activity_path.write_text("")
+
+    message = f"Dynamic analysis complete for {serial}"
+    log.info(message)
     print(message)
+    print(f"Logcat saved to {logcat_path}")
+    print(f"Activity dump saved to {activity_path}")
+
+    return {"logcat": logcat_path, "activity": activity_path}
 

--- a/scripts/run_dynamic_analysis.py
+++ b/scripts/run_dynamic_analysis.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""CLI helper to run basic dynamic analysis on a device."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from analysis.dynamic_analysis.run_dynamic_analysis import run_dynamic_analysis
+from utils.adb_utils.adb_devices import get_connected_devices
+
+
+def _resolve_serial(provided: str | None) -> str | None:
+    """Return a serial either from argument or first connected device."""
+    if provided:
+        return provided
+    devices = get_connected_devices()
+    return devices[0].serial if devices else None
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for the dynamic analysis helper."""
+    parser = argparse.ArgumentParser(description="Run basic dynamic analysis on a device")
+    parser.add_argument(
+        "serial",
+        nargs="?",
+        help="Target device serial; defaults to first connected device",
+    )
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Directory where analysis artefacts are written",
+    )
+    parser.add_argument(
+        "-d",
+        "--duration",
+        type=int,
+        default=15,
+        help="Maximum seconds to allow each adb command to run",
+    )
+    args = parser.parse_args(argv)
+
+    serial = _resolve_serial(args.serial)
+    if not serial:
+        print("No devices connected")
+        return 1
+
+    run_dynamic_analysis(serial, output_dir=args.output_dir, duration=args.duration)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_run_dynamic_analysis.py
+++ b/tests/test_run_dynamic_analysis.py
@@ -1,6 +1,8 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))
@@ -8,7 +10,32 @@ if str(ROOT) not in sys.path:
 from analysis.dynamic_analysis.run_dynamic_analysis import run_dynamic_analysis
 
 
-def test_run_dynamic_analysis_placeholder(capsys):
-    run_dynamic_analysis("serial123")
-    out = capsys.readouterr().out.strip()
-    assert out == "Dynamic analysis not yet implemented for serial123"
+def test_run_dynamic_analysis_collects_logs(tmp_path, capsys, monkeypatch):
+    calls = []
+
+    def fake_run_adb_command(serial, args, timeout=15, capture_stderr=False, log_errors=True):
+        calls.append((serial, args, timeout))
+        if args == ["logcat", "-d"]:
+            return {"success": True, "output": "log output", "error": ""}
+        if args == ["shell", "dumpsys", "activity", "activities"]:
+            return {"success": True, "output": "activity output", "error": ""}
+        return {"success": False, "output": "", "error": "unexpected"}
+
+    monkeypatch.setattr(
+        "analysis.dynamic_analysis.run_dynamic_analysis.run_adb_command",
+        fake_run_adb_command,
+    )
+
+    paths = run_dynamic_analysis("serial123", output_dir=tmp_path, duration=5)
+
+    out_lines = capsys.readouterr().out.strip().splitlines()
+    assert "Dynamic analysis complete for serial123" in out_lines[0]
+    assert (tmp_path / "logcat.txt").read_text() == "log output"
+    assert (tmp_path / "activity.txt").read_text() == "activity output"
+    assert paths["logcat"] == tmp_path / "logcat.txt"
+    assert paths["activity"] == tmp_path / "activity.txt"
+
+    # Ensure duration parameter is forwarded to adb commands
+    assert calls[0][2] == 5
+    assert calls[1][2] == 5
+

--- a/tests/test_run_dynamic_analysis_script.py
+++ b/tests/test_run_dynamic_analysis_script.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+from scripts import run_dynamic_analysis as script
+from utils.adb_utils.adb_devices import DeviceInfo
+
+
+def test_main_with_explicit_serial(monkeypatch):
+    called = {}
+
+    def fake_run_dynamic_analysis(serial, output_dir=None, duration=15):
+        called['serial'] = serial
+        called['output_dir'] = output_dir
+        called['duration'] = duration
+
+    monkeypatch.setattr(script, 'run_dynamic_analysis', fake_run_dynamic_analysis)
+    exit_code = script.main(['SER123', '-o', 'out', '-d', '20'])
+    assert exit_code == 0
+    assert called['serial'] == 'SER123'
+    assert called['output_dir'] == Path('out')
+    assert called['duration'] == 20
+
+
+def test_main_uses_first_connected(monkeypatch):
+    device = DeviceInfo(serial='SER456', state='device', model='m', type='Physical')
+    monkeypatch.setattr(script, 'get_connected_devices', lambda: [device])
+
+    called = {}
+
+    def fake_run_dynamic_analysis(serial, output_dir=None, duration=15):
+        called['serial'] = serial
+        return {'logcat': Path('lc'), 'activity': Path('act')}
+
+    monkeypatch.setattr(script, 'run_dynamic_analysis', fake_run_dynamic_analysis)
+    exit_code = script.main([])
+    assert exit_code == 0
+    assert called['serial'] == 'SER456'
+


### PR DESCRIPTION
## Summary
- return paths to logcat and activity dump from dynamic analysis
- add command line helper to run dynamic analysis on a device
- extend tests for analysis and new CLI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7f53d0dac832799c59b5bf0e46b48