### PR TITLE
Add CSV utilities and integrate with static analysis reports

### DIFF
--- a/analysis/static_analysis/run_static_analysis.py
+++ b/analysis/static_analysis/run_static_analysis.py
@@ -28,6 +28,10 @@ def analyze_device(serial: str, artifact_limit: int | None = None) -> None:
 
     print(f"Analyzing {len(reports)} package(s)")
     report_formatter.print_reports(reports, serial, artifact_limit)
+    # Persist a machine-readable listing for downstream tooling
+    print("[run_static_analysis] Writing apk_list.csv for debug")
+    report_formatter.write_csv_report(reports, "apk_list.csv")
+    print("[run_static_analysis] apk_list.csv write complete")
     print(f"✅ Static analysis complete for {serial}")
     log.info(f"Static analysis complete for {serial}")
 

--- a/tests/test_csv_utils.py
+++ b/tests/test_csv_utils.py
@@ -1,0 +1,52 @@
+import csv
+from utils import csv_utils
+from analysis.static_analysis import report_formatter
+
+
+class DummyReport:
+    def __init__(self, name, apk_path, category, risk_score):
+        self.name = name
+        self.apk_path = apk_path
+        self.category = category
+        self.risk_score = risk_score
+
+
+def test_write_csv_sorts_and_enforces_headers(tmp_path):
+    path = tmp_path / "out.csv"
+    rows = [
+        {"Package": "bbb", "APK_Path": "/b", "Extra": "2"},
+        {"Package": "Aaa", "APK_Path": "/a", "Extra": "1"},
+    ]
+    csv_utils.write_csv(path, rows, headers=["Extra"])
+    content = path.read_text(encoding="utf-8")
+    lines = content.splitlines()
+    assert lines[0] == "Package,APK_Path,Extra"
+    assert lines[1].startswith("Aaa")
+    assert content.endswith("\n")
+    assert "\r\n" not in content
+
+
+def test_read_and_validate_apk_list(tmp_path):
+    path = tmp_path / "apk_list.csv"
+    rows = [{"Package": "com.example", "APK_Path": "/a.apk"}]
+    csv_utils.write_csv(path, rows, headers=[])
+    assert csv_utils.validate_apk_list(path)
+    read_rows = csv_utils.read_apk_list(path)
+    assert read_rows == rows
+
+    invalid = tmp_path / "bad.csv"
+    invalid.write_text("Wrong,Header\n", encoding="utf-8")
+    assert not csv_utils.validate_apk_list(invalid)
+
+    invalid2 = tmp_path / "bad2.csv"
+    invalid2.write_text("Package,APK_Path\npkg,\n", encoding="utf-8")
+    assert not csv_utils.validate_apk_list(invalid2)
+
+
+def test_report_formatter_writes_valid_csv(tmp_path):
+    path = tmp_path / "apk_list.csv"
+    reports = [DummyReport("com.app", "/app.apk", "util", 5)]
+    report_formatter.write_csv_report(reports, path)
+    assert csv_utils.validate_apk_list(path)
+    rows = csv_utils.read_apk_list(path)
+    assert rows[0]["Package"] == "com.app"

--- a/utils/csv_utils.py
+++ b/utils/csv_utils.py
@@ -1,0 +1,98 @@
+"""CSV helper utilities for project.
+
+Provides a ``write_csv`` helper that enforces ``Package`` and ``APK_Path``
+headers and ensures deterministic row ordering.  Additional helpers assist
+with reading and validating APK lists.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Sequence, Mapping, Any, List, Dict
+import csv
+
+# Debugging helper prefix for all prints from this module
+_DEBUG_PREFIX = "[csv_utils]"
+
+
+_BASE_HEADERS = ["Package", "APK_Path"]
+
+
+def _coerce_mapping(row: Mapping[str, Any] | Any, headers: Sequence[str]) -> Dict[str, Any]:
+    """Return ``row`` as a mapping for ``headers``.
+
+    ``row`` may already be a mapping or an object with attributes matching the
+    headers.
+    """
+
+    if isinstance(row, Mapping):
+        return {h: row.get(h) for h in headers}
+    return {h: getattr(row, h, None) for h in headers}
+
+
+def write_csv(path: str | Path, rows: Iterable[Mapping[str, Any] | Any], headers: Sequence[str]) -> None:
+    """Write ``rows`` to ``path`` using UTF-8 encoding and ``\n`` line endings.
+
+    The first two headers are forced to be ``Package`` and ``APK_Path``. Any
+    additional ``headers`` are appended after these.  Rows are sorted
+    case-insensitively by the ``Package`` column.
+    """
+
+    path = Path(path)
+    extra_headers = [h for h in headers if h not in _BASE_HEADERS]
+    fieldnames = _BASE_HEADERS + list(extra_headers)
+    print(f"{_DEBUG_PREFIX} Preparing to write CSV to {path} with headers: {fieldnames}")
+
+    coerced_rows: List[Dict[str, Any]] = []
+    for row in rows:
+        coerced = _coerce_mapping(row, fieldnames)
+        coerced_rows.append(coerced)
+    print(f"{_DEBUG_PREFIX} Coerced {len(coerced_rows)} row(s) for output")
+
+    coerced_rows.sort(key=lambda r: (str(r.get("Package", "")).lower()))
+    print(f"{_DEBUG_PREFIX} Sorted rows by 'Package' header")
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="\n") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in coerced_rows:
+            writer.writerow(row)
+    print(f"{_DEBUG_PREFIX} Wrote {len(coerced_rows)} row(s) to {path}")
+
+
+def read_apk_list(path: str | Path) -> List[Dict[str, str]]:
+    """Read an ``apk_list.csv`` style file into a list of dictionaries."""
+
+    path = Path(path)
+    print(f"{_DEBUG_PREFIX} Reading APK list from {path}")
+    with path.open(encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        rows = [dict(row) for row in reader]
+    print(f"{_DEBUG_PREFIX} Loaded {len(rows)} row(s) from {path}")
+    return rows
+
+
+def validate_apk_list(path: str | Path) -> bool:
+    """Return ``True`` if ``path`` exists and appears to be a valid APK list."""
+
+    print(f"{_DEBUG_PREFIX} Validating APK list at {path}")
+    try:
+        path = Path(path)
+        with path.open(encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            if not reader.fieldnames:
+                print(f"{_DEBUG_PREFIX} Validation failed: missing headers")
+                return False
+            if reader.fieldnames[:2] != _BASE_HEADERS:
+                print(f"{_DEBUG_PREFIX} Validation failed: incorrect base headers {reader.fieldnames[:2]}")
+                return False
+            for idx, row in enumerate(reader, start=1):
+                if not row.get("Package") or not row.get("APK_Path"):
+                    print(f"{_DEBUG_PREFIX} Validation failed: missing data at row {idx}")
+                    return False
+    except OSError as exc:
+        print(f"{_DEBUG_PREFIX} Validation failed: {exc}")
+        return False
+    print(f"{_DEBUG_PREFIX} Validation succeeded for {path}")
+    return True


### PR DESCRIPTION
## Summary
- Implement csv_utils with write_csv enforcing Package/APK_Path headers, case-insensitive sorting, and UTF-8 newline handling
- Add helpers to read and validate APK list CSV files
- Export static analysis results to `apk_list.csv` via new report formatter utility
- Emit detailed debug prints and connectivity checks across CSV utilities and static analysis workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8b9aacb408327bba35bbcfae9f4eb