### PR TITLE
Ensure ADB device readiness and add centralized main menu

### DIFF
--- a/analysis/static_analysis/run_static_analysis.py
+++ b/analysis/static_analysis/run_static_analysis.py
@@ -100,7 +100,7 @@ def list_social_apps(serial: str) -> None:
 
 
 def _resolve_serial(provided: str | None) -> str | None:
-    """Return a serial either from argument or user selection."""
+    """Return a serial either from argument or automatic selection."""
 
     devices = get_connected_devices()
     if provided:
@@ -114,24 +114,13 @@ def _resolve_serial(provided: str | None) -> str | None:
         print("No connected devices found")
         return None
 
-    if len(devices) == 1:
-        serial = devices[0].serial
-        print(f"Using connected device: {serial}")
-        return serial
-
-    print("Multiple devices detected:")
-    for idx, dev in enumerate(devices, start=1):
-        model = getattr(dev, "model", "unknown") or "unknown"
-        print(f" {idx}. {dev.serial} ({model})")
-
-    choice = input("Select device number: ").strip()
-    try:
-        selected = devices[int(choice) - 1]
-        print(f"Selected device: {selected.serial}")
-        return selected.serial
-    except (ValueError, IndexError):
-        print("Invalid selection")
+    if len(devices) > 1:
+        print("Multiple devices detected. Specify one with --device.")
         return None
+
+    serial = devices[0].serial
+    print(f"Using connected device: {serial}")
+    return serial
 
 
 def validate_apk_path(apk_path: str) -> bool:

--- a/database/db_menu.py
+++ b/database/db_menu.py
@@ -1,37 +1,58 @@
-"""Minimal interactive database menu for testing connection."""
+"""Interactive database menu implemented as a class.
+
+This module previously exposed a simple function that rendered a menu
+using ``menu_utils``.  To better align with the object's oriented design of
+the rest of the CLI, it now provides :class:`DatabaseMenu` which inherits
+from :class:`menus.base.BaseMenu`.
+
+The menu currently exposes a single action to test the database
+connection but can easily be extended with additional options in the
+future.
+"""
 
 from __future__ import annotations
 
+from menus.base import BaseMenu, MenuAction
 from database.db_core import DatabaseCore
 from database.db_engine import DbEngine
-from utils.display_utils import menu_utils, error_utils
+from utils.display_utils import error_utils
 
 
-def _test_connection() -> None:
-    """Attempt to connect to the database and report status."""
-    core = DatabaseCore.from_config()
-    engine = DbEngine(core)
-    try:
-        engine.init()
-        if engine.is_ready():
-            print("✅ Database connection successful.")
-        else:  # pragma: no cover - defensive branch
-            print("❌ Database connection failed.")
-    except Exception as exc:  # pragma: no cover - depends on database
-        error_utils.show_error(f"Connection failed: {exc}")
-    finally:
+class DatabaseMenu(BaseMenu):
+    """Small menu for database related utilities."""
+
+    def __init__(self) -> None:  # pragma: no cover - simple wiring
+        super().__init__(title="Database Menu", exit_label="Back")
+        self.actions = {
+            "1": MenuAction("Test Connection", self.test_connection),
+        }
+
+    def test_connection(self) -> None:
+        """Attempt to connect to the configured database and report status."""
+        core = DatabaseCore.from_config()
+        engine = DbEngine(core)
         try:
-            engine.shutdown()
-        except Exception:  # pragma: no cover - defensive shutdown
-            pass
+            engine.init()
+            if engine.is_ready():
+                print("✅ Database connection successful.")
+            else:  # pragma: no cover - defensive branch
+                print("❌ Database connection failed.")
+        except Exception as exc:  # pragma: no cover - depends on database
+            error_utils.show_error(f"Connection failed: {exc}")
+        finally:
+            try:
+                engine.shutdown()
+            except Exception:  # pragma: no cover - defensive shutdown
+                pass
 
 
+# ---------------------------------------------------------------------------
+# Convenience wrapper
+# ---------------------------------------------------------------------------
 def db_menu() -> None:
-    """Display a simple menu for database utilities."""
-    options = {
-        "1": ("Test Connection", _test_connection),
-    }
-    menu_utils.show_menu("Database Menu", options, exit_label="Back")
+    """Render the :class:`DatabaseMenu` (backwards compatible helper)."""
+    DatabaseMenu().show()
 
 
-__all__ = ["db_menu"]
+__all__ = ["DatabaseMenu", "db_menu"]
+

--- a/device/device_menu.py
+++ b/device/device_menu.py
@@ -1,103 +1,123 @@
 # device/device_menu.py
+"""Interactive device menu implemented with an object-oriented design."""
 
 import sys
 import subprocess
 
 from utils.adb_utils import adb_ip_lookup
+from utils.adb_utils import adb_runner
+from utils.adb_utils.adb_client import ADBClient
 from utils.adb_utils.adb_devices import DeviceInfo
 from utils.adb_utils.adb_root import attempt_root
 from device import vendor_normalizer
-from utils.display_utils import prompt_utils, menu_utils
+from utils.display_utils import prompt_utils
 from utils.display_utils.menu_utils import MenuExit
-from analysis.static_analysis import run_static_analysis   # <-- import
+from menus.base import BaseMenu, MenuAction
+from analysis.static_analysis import run_static_analysis
 from config import app_config
 import utils.logging_utils.logging_engine as log
 
 
-def interactive_device_menu(device: DeviceInfo):
-    """Interactive menu after connecting to a device."""
-    serial = device.serial
-    details = device.details
-    vendor = vendor_normalizer.normalize_vendor(details)
-    model = details.get("model", "unknown")
+class DeviceMenu(BaseMenu):
+    """Menu shown after connecting to a specific device."""
 
-    ip = adb_ip_lookup.get_ip_for_device(serial)
-    log.info(
-        f"Opened device menu for {serial} (vendor={vendor}, model={model}, ip={ip or 'N/A'})"
-    )
+    def __init__(self, device: DeviceInfo) -> None:
+        self.device = device
+        self.serial = device.serial
+        self.adb = ADBClient(self.serial)
+        self.details = device.details
+        self.vendor = vendor_normalizer.normalize_vendor(self.details)
+        self.model = self.details.get("model", "unknown")
+        self.ip = adb_ip_lookup.get_ip_for_device(self.serial)
+        super().__init__(title="Device Menu", exit_label="Back")
+        self.actions = {
+            "1": MenuAction("Show device info", self.show_info),
+            "2": MenuAction("Open adb shell", self.open_shell),
+            "3": MenuAction("Run static analysis", self.run_static_analysis),
+            "4": MenuAction("Gain root access", self.gain_root_access),
+            "5": MenuAction("Disconnect", self.disconnect),
+            "6": MenuAction("Reboot device", self.reboot_device),
+            "7": MenuAction("Exit program", self.exit_program),
+        }
+        log.info(
+            f"Opened device menu for {self.serial} (vendor={self.vendor}, model={self.model}, ip={self.ip or 'N/A'})"
+        )
 
-    # Device info header
-    print("\n📱 Connected to Device")
-    print("----------------------")
-    print(f"Serial   : {serial}")
-    print(f"Vendor   : {vendor}")
-    print(f"Model    : {model}")
-    if ip:
-        print(f"IP Addr  : {ip}")
+    def show(self) -> None:  # type: ignore[override]
+        """Display header info before rendering menu."""
+        print("\n📱 Connected to Device")
+        print("----------------------")
+        print(f"Serial   : {self.serial}")
+        print(f"Vendor   : {self.vendor}")
+        print(f"Model    : {self.model}")
+        if self.ip:
+            print(f"IP Addr  : {self.ip}")
+        super().show()
+        log.info(f"Exiting device menu for {self.serial}")
 
-    # Device actions
-    def show_info():
+    # ----- Action handlers -----
+    def show_info(self) -> None:
         print("\n[INFO] Device Details")
         print("----------------------")
-        print(f"Serial   : {serial}")
-        print(f"Vendor   : {vendor}")
-        print(f"Model    : {model}")
-        print(f"IP Addr  : {ip or 'N/A'}")
-        log.debug(f"Displayed device info for {serial}")
+        print(f"Serial   : {self.serial}")
+        print(f"Vendor   : {self.vendor}")
+        print(f"Model    : {self.model}")
+        print(f"IP Addr  : {self.ip or 'N/A'}")
+        log.debug(f"Displayed device info for {self.serial}")
 
-    def open_shell():
-        if prompt_utils.ask_yes_no(f"Open adb shell for {serial}?", default="y"):
-            print(f"\n[ADB SHELL] Opening shell for {serial}...\n")
-            subprocess.run(["adb", "-s", serial, "shell"])
-            log.info(f"ADB shell opened for {serial}")
+    def open_shell(self) -> None:
+        if prompt_utils.ask_yes_no(f"Open adb shell for {self.serial}?", default="y"):
+            res = self.adb.interactive_shell()
+            if res.get("success"):
+                print(f"\n[ADB SHELL] Opening shell for {self.serial}...\n")
+                log.info(f"ADB shell opened for {self.serial}")
+            else:
+                print(f"❌ Device {self.serial} not ready: {res.get('error')}")
+                log.error(f"Device {self.serial} not ready: {res.get('error')}")
 
-    def run_static():
+    def run_static_analysis(self) -> None:
         print("\n🔍 Running static analysis...\n")
         try:
-            log.info(f"Launching static analysis for {serial}")
+            log.info(f"Launching static analysis for {self.serial}")
             limit = getattr(app_config, "ARTIFACT_LIMIT", 3)
-            run_static_analysis.analyze_device(serial, artifact_limit=limit)
-            log.info(f"Static analysis finished for {serial}")
+            run_static_analysis.analyze_device(self.serial, artifact_limit=limit)
+            log.info(f"Static analysis finished for {self.serial}")
         except KeyboardInterrupt:
             print("\n⚠️  Static analysis interrupted. Returning to menu.\n")
-            log.warning(f"Static analysis interrupted for {serial}")
+            log.warning(f"Static analysis interrupted for {self.serial}")
         except Exception as e:
             print(f"❌ Static analysis failed: {e}")
-            log.error(f"Static analysis failed for {serial}: {e}")
+            log.error(f"Static analysis failed for {self.serial}: {e}")
 
-    def gain_root():
-        if prompt_utils.ask_yes_no(f"Attempt root access for {serial}?", default="n"):
-            success = attempt_root(serial)
+    def gain_root_access(self) -> None:
+        if prompt_utils.ask_yes_no(f"Attempt root access for {self.serial}?", default="n"):
+            success = attempt_root(self.serial)
             msg = "Root access granted" if success else "Root access denied"
-            print(f"\n{msg} for {serial}")
+            print(f"\n{msg} for {self.serial}")
 
-    def disconnect():
-        if prompt_utils.ask_yes_no(f"Disconnect from {serial}?", default="y"):
-            print(f"\n🔌 Disconnected from {serial}")
-            log.info(f"Disconnected from {serial}")
+    def disconnect(self) -> None:
+        if prompt_utils.ask_yes_no(f"Disconnect from {self.serial}?", default="y"):
+            print(f"\n🔌 Disconnected from {self.serial}")
+            log.info(f"Disconnected from {self.serial}")
             raise MenuExit
 
-    def reboot():
-        if prompt_utils.ask_yes_no(f"Reboot {serial}?", default="y"):
-            subprocess.run(["adb", "-s", serial, "reboot"])
-            print(f"\n🔄 Rebooted {serial}")
-            log.info(f"Reboot command issued for {serial}")
+    def reboot_device(self) -> None:
+        if prompt_utils.ask_yes_no(f"Reboot {self.serial}?", default="y"):
+            res = self.adb.reboot()
+            if res.get("success"):
+                print(f"\n🔄 Rebooted {self.serial}")
+                log.info(f"Reboot command issued for {self.serial}")
+            else:
+                print(f"❌ Device {self.serial} not ready: {res.get('error')}")
+                log.error(f"Failed to reboot {self.serial}: {res.get('error')}")
 
-    def exit_program():
+    def exit_program(self) -> None:
         if prompt_utils.ask_yes_no("Exit program?", default="n"):
             print("\n👋 Exiting.")
             log.critical("User requested program exit from device menu")
             sys.exit(0)
 
-    options = {
-        "1": ("Show device info", show_info),
-        "2": ("Open adb shell", open_shell),
-        "3": ("Run static analysis", run_static),
-        "4": ("Gain root access", gain_root),
-        "5": ("Disconnect", disconnect),
-        "6": ("Reboot device", reboot),
-        "7": ("Exit program", exit_program),
-    }
 
-    menu_utils.show_menu("Device Menu", options, exit_label="Back")
-    log.info(f"Exiting device menu for {serial}")
+def interactive_device_menu(device: DeviceInfo) -> None:
+    """Wrapper for backward compatibility."""
+    DeviceMenu(device).show()

--- a/main.py
+++ b/main.py
@@ -1,45 +1,13 @@
 # main.py
-import sys
 import signal
 import argparse
 import logging
 
 from config import app_config
-from utils.display_utils import menu_utils, error_utils, theme
+from utils.display_utils import theme
 import utils.logging_utils.logging_engine as log
-from device import show_devices, connect_to_device
-from utils.about_app import about_app
-from database.db_menu import db_menu
 
-
-# ---------- Menu Actions ----------
-
-def action_show_connected_devices():
-    """Action: List all connected Android devices."""
-    log.info("Selected: Show Connected Devices")
-    try:
-        show_devices.display_detailed_devices()
-    except KeyboardInterrupt:
-        print("\n⚠️  Device listing interrupted.\n")
-        log.warning("Device listing interrupted by user")
-
-
-def action_connect_to_device():
-    """Action: Connect to a selected device and open interactive menu."""
-    log.info("Selected: Connect to a Device")
-    try:
-        connect_to_device.connect_to_device()
-    except KeyboardInterrupt:
-        print("\n⚠️  Device connection interrupted. Returning to main menu.\n")
-        log.warning("Device connection interrupted by user")
-    except Exception as e:
-        error_utils.show_error(f"Failed to connect to device: {e}")
-
-
-def action_database_menu():
-    """Action: Open interactive database menu."""
-    log.info("Opened Database Menu")
-    db_menu()
+from main_menu import MainMenu
 
 
 # ---------- Signal Handling ----------
@@ -114,20 +82,8 @@ def main():
     # Trap Ctrl+C
     signal.signal(signal.SIGINT, handle_interrupt)
 
-    # Define main menu
-    options = {
-        "1": ("Show Connected Devices", action_show_connected_devices),
-        "2": ("Connect to a Device", action_connect_to_device),
-        "3": ("Database", action_database_menu),
-        "4": ("About App", about_app),
-    }
-
     try:
-        menu_utils.show_menu(
-            title=f"{app_config.APP_NAME} v{app_config.APP_VERSION}",
-            options=options,
-            exit_label="Exit",
-        )
+        MainMenu().show()
     except KeyboardInterrupt:
         print("\n⚠️  Main menu interrupted. Exiting.\n")
         log.warning("Main menu interrupted by user")

--- a/main_menu.py
+++ b/main_menu.py
@@ -1,0 +1,98 @@
+# main_menu.py
+"""Centralized main menu using an object-oriented design."""
+
+from config import app_config
+from menus.base import BaseMenu, MenuAction
+from utils.display_utils import error_utils
+import utils.logging_utils.logging_engine as log
+from device import show_devices, connect_to_device
+from utils.about_app import about_app
+from database.db_menu import DatabaseMenu
+from utils.test_utils.test_runner import PytestRunner
+
+
+class MainMenu(BaseMenu):
+    """Primary application menu."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            title=f"{app_config.APP_NAME} v{app_config.APP_VERSION}",
+            exit_label="Exit",
+            highlight_choice="1",
+            highlight_style="accent",
+        )
+        self.actions = {
+            "1": MenuAction("Show Connected Devices", self.show_connected_devices),
+            "2": MenuAction("Connect to a Device", self.connect_to_device),
+            "3": MenuAction("Database", self.open_database_menu),
+            "4": MenuAction("Run Test Suite", self.run_test_suite),
+            "5": MenuAction("About App", about_app),
+        }
+
+    # ----- Menu Action Methods -----
+    def show_connected_devices(self) -> None:
+        """List all connected Android devices."""
+        log.info("Selected: Show Connected Devices")
+        try:
+            show_devices.display_detailed_devices()
+        except KeyboardInterrupt:
+            print("\n⚠️  Device listing interrupted.\n")
+            log.warning("Device listing interrupted by user")
+
+    def connect_to_device(self) -> None:
+        """Connect to a selected device and open its menu."""
+        log.info("Selected: Connect to a Device")
+        try:
+            connect_to_device.connect_to_device()
+        except KeyboardInterrupt:
+            print("\n⚠️  Device connection interrupted. Returning to main menu.\n")
+            log.warning("Device connection interrupted by user")
+        except Exception as e:  # pragma: no cover - defensive
+            error_utils.show_error(f"Failed to connect to device: {e}")
+
+    def open_database_menu(self) -> None:
+        """Open the interactive database menu."""
+        log.info("Opened Database Menu")
+        DatabaseMenu().show()
+
+    def run_test_suite(self) -> None:
+        """Execute the full pytest suite and show results."""
+        log.info("Selected: Run Test Suite")
+        print("\n🧪 Running test suite...\n")
+        PytestRunner().run_and_report()
+
+
+# ----- Convenience wrappers -----
+def show_main_menu() -> None:
+    """Render the main menu."""
+    MainMenu().show()
+
+
+def action_run_tests() -> None:
+    """Maintain backward compatibility for test runner."""
+    MainMenu().run_test_suite()
+
+
+def action_database_menu() -> None:
+    """Backward-compatible helper to open the database menu."""
+    MainMenu().open_database_menu()
+
+
+def action_show_connected_devices() -> None:
+    """Backward-compatible helper to list connected devices."""
+    MainMenu().show_connected_devices()
+
+
+def action_connect_to_device() -> None:
+    """Backward-compatible helper to connect to a device."""
+    MainMenu().connect_to_device()
+
+
+__all__ = [
+    "MainMenu",
+    "show_main_menu",
+    "action_run_tests",
+    "action_database_menu",
+    "action_show_connected_devices",
+    "action_connect_to_device",
+]

--- a/menus/base.py
+++ b/menus/base.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass, field
+from typing import Callable, Dict, Optional
+
+from utils.display_utils import menu_utils
+
+
+@dataclass
+class MenuAction:
+    """Represents a single menu entry and its handler."""
+    label: str
+    handler: Callable[[], None]
+
+
+@dataclass
+class BaseMenu:
+    """Simple object-oriented wrapper around menu rendering."""
+    title: str
+    exit_label: str = "Exit"
+    highlight_choice: Optional[str] = None
+    highlight_style: str = "accent"
+    actions: Dict[str, MenuAction] = field(default_factory=dict)
+
+    def show(self) -> None:
+        """Render the menu using ``menu_utils``."""
+        options = {k: (a.label, a.handler) for k, a in self.actions.items()}
+        menu_utils.show_menu(
+            title=self.title,
+            options=options,
+            exit_label=self.exit_label,
+            highlight_choice=self.highlight_choice,
+            highlight_style=self.highlight_style,
+        )

--- a/scripts/run_dynamic_analysis.py
+++ b/scripts/run_dynamic_analysis.py
@@ -11,7 +11,7 @@ from utils.adb_utils.adb_devices import get_connected_devices
 
 
 def _resolve_serial(provided: str | None) -> str | None:
-    """Return a serial either from argument or user selection."""
+    """Return a serial either from argument or automatic selection."""
 
     if provided:
         print(f"Using provided serial: {provided}")
@@ -21,32 +21,21 @@ def _resolve_serial(provided: str | None) -> str | None:
     if not devices:
         return None
 
-    if len(devices) == 1:
-        print(f"Using connected device: {devices[0].serial}")
-        return devices[0].serial
-
-    print("Multiple devices detected:")
-    for idx, dev in enumerate(devices, start=1):
-        model = getattr(dev, "model", "unknown") or "unknown"
-        print(f" {idx}. {dev.serial} ({model})")
-
-    choice = input("Select device number: ").strip()
-    try:
-        selected = devices[int(choice) - 1]
-        print(f"Selected device: {selected.serial}")
-        return selected.serial
-    except (ValueError, IndexError):
-        print("Invalid selection")
+    if len(devices) > 1:
+        print("Multiple devices detected. Specify one with --device.")
         return None
+
+    print(f"Using connected device: {devices[0].serial}")
+    return devices[0].serial
 
 
 def main(argv: list[str] | None = None) -> int:
     """Entry point for the dynamic analysis helper."""
     parser = argparse.ArgumentParser(description="Run basic dynamic analysis on a device")
     parser.add_argument(
-        "serial",
-        nargs="?",
-        help="Target device serial; defaults to first connected device",
+        "--device",
+        dest="serial",
+        help="Target device serial; required if multiple devices are connected",
     )
     parser.add_argument(
         "-o",

--- a/tests/test_adb_client.py
+++ b/tests/test_adb_client.py
@@ -1,0 +1,30 @@
+from utils.adb_utils.adb_client import ADBClient
+from utils.adb_utils import adb_runner
+
+
+def test_list_devices(monkeypatch):
+    def fake_run(serial, args, timeout=15, capture_stderr=False, log_errors=True):
+        assert serial is None
+        assert args == ['devices']
+        out = 'List of devices attached\nX\tdevice\nY\tdevice\n'
+        return {'success': True, 'output': out, 'error': ''}
+
+    monkeypatch.setattr(adb_runner, 'run_adb_command', fake_run)
+
+    devices = ADBClient.list_devices()
+    assert devices == ['X', 'Y']
+
+
+def test_shell_command(monkeypatch):
+    calls = []
+
+    def fake_run(serial, args, timeout=15, capture_stderr=False, log_errors=True):
+        calls.append((serial, args))
+        return {'success': True, 'output': 'ok', 'error': ''}
+
+    monkeypatch.setattr(adb_runner, 'run_adb_command', fake_run)
+
+    client = ADBClient('serial123')
+    res = client.shell('id')
+    assert res['success']
+    assert calls == [('serial123', ['shell', 'id'])]

--- a/tests/test_adb_runner.py
+++ b/tests/test_adb_runner.py
@@ -1,0 +1,16 @@
+from utils.adb_utils import adb_runner
+
+
+def test_run_adb_command_errors_on_multiple(monkeypatch):
+    def fake_execute(cmd, timeout=15, capture_stderr=False, log_errors=True):
+        if cmd[:3] == ['adb', 'devices', '-l']:
+            out = 'List of devices attached\nA\tdevice\nB\tdevice\n'
+            return {'success': True, 'output': out, 'error': ''}
+        return {'success': True, 'output': '', 'error': ''}
+
+    monkeypatch.setattr(adb_runner, 'execute_command', fake_execute)
+    monkeypatch.setattr(adb_runner, 'is_adb_available', lambda log_errors=True: True)
+
+    res = adb_runner.run_adb_command(None, ['shell', 'id'])
+    assert not res['success']
+    assert 'Multiple devices' in res['error']

--- a/tests/test_db_menu.py
+++ b/tests/test_db_menu.py
@@ -23,10 +23,10 @@ def test_db_menu_provides_test_connection_option_and_uses_engine():
 
     with mock.patch.object(db_menu_mod, "DbEngine", return_value=fake_engine) as eng_cls, \
          mock.patch.object(db_menu_mod, "DatabaseCore") as core_cls, \
-         mock.patch.object(db_menu_mod.menu_utils, "show_menu") as show_menu:
+         mock.patch("menus.base.menu_utils.show_menu") as show_menu:
         core_cls.from_config.return_value = fake_core
 
-        def fake_show_menu(title, options, exit_label):
+        def fake_show_menu(title, options, exit_label, highlight_choice=None, highlight_style='accent'):
             # Menu contains only the test connection option
             assert options["1"][0].lower().startswith("test")
             # Simulate selecting the option
@@ -44,8 +44,9 @@ def test_db_menu_provides_test_connection_option_and_uses_engine():
 
 
 def test_action_database_menu_invokes_db_menu():
-    import main
+    import main_menu
 
-    with mock.patch.object(main, "db_menu") as menu:
-        main.action_database_menu()
-        menu.assert_called_once()
+    with mock.patch.object(main_menu, "DatabaseMenu") as menu_cls:
+        instance = menu_cls.return_value
+        main_menu.action_database_menu()
+        instance.show.assert_called_once()

--- a/tests/test_run_dynamic_analysis_script.py
+++ b/tests/test_run_dynamic_analysis_script.py
@@ -13,7 +13,7 @@ def test_main_with_explicit_serial(monkeypatch):
         called['duration'] = duration
 
     monkeypatch.setattr(script, 'run_dynamic_analysis', fake_run_dynamic_analysis)
-    exit_code = script.main(['SER123', '-o', 'out', '-d', '20'])
+    exit_code = script.main(['--device', 'SER123', '-o', 'out', '-d', '20'])
     assert exit_code == 0
     assert called['serial'] == 'SER123'
     assert called['output_dir'] == Path('out')
@@ -34,4 +34,16 @@ def test_main_uses_first_connected(monkeypatch):
     exit_code = script.main([])
     assert exit_code == 0
     assert called['serial'] == 'SER456'
+
+
+def test_main_errors_on_multiple(monkeypatch, capsys):
+    devices = [
+        DeviceInfo(serial='A', state='device', model='m', type='Physical'),
+        DeviceInfo(serial='B', state='device', model='m', type='Physical'),
+    ]
+    monkeypatch.setattr(script, 'get_connected_devices', lambda: devices)
+    exit_code = script.main([])
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert 'Multiple devices detected' in out
 

--- a/tests/test_run_static_analysis.py
+++ b/tests/test_run_static_analysis.py
@@ -95,6 +95,14 @@ def test_resolve_serial_rejects_unknown(monkeypatch, capsys):
     assert 'not connected' in out
 
 
+def test_resolve_serial_multiple(monkeypatch, capsys):
+    monkeypatch.setattr(run_static_analysis, 'get_connected_devices', lambda: [Dummy('A'), Dummy('B')])
+    serial = run_static_analysis._resolve_serial(None)
+    assert serial is None
+    out = capsys.readouterr().out
+    assert 'Multiple devices detected' in out
+
+
 def test_scan_package_strings_reports_artifacts(monkeypatch, capsys):
     monkeypatch.setattr(run_static_analysis.string_finder, 'find_artifacts', lambda s, p: ['hit'])
     monkeypatch.setattr(run_static_analysis.string_finder, 'print_failure_summary', lambda: None)

--- a/tests/test_run_tests_menu.py
+++ b/tests/test_run_tests_menu.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from main_menu import MainMenu
+from utils.test_utils.test_runner import PytestRunner
+
+
+def test_run_tests_success(monkeypatch, capsys):
+    called = {}
+
+    class DummyResult:
+        returncode = 0
+
+    def fake_run(self):
+        called['args'] = self.args
+        return DummyResult()
+
+    monkeypatch.setattr(PytestRunner, 'run', fake_run)
+    MainMenu().run_test_suite()
+    out = capsys.readouterr().out
+    assert 'Running test suite' in out
+    assert 'All tests passed' in out
+    assert called['args'] == ['pytest']
+
+
+def test_run_tests_failure(monkeypatch, capsys):
+    class DummyResult:
+        returncode = 1
+
+    monkeypatch.setattr(PytestRunner, 'run', lambda self: DummyResult())
+    MainMenu().run_test_suite()
+    out = capsys.readouterr().out
+    assert 'Some tests failed' in out

--- a/utils/adb_utils/adb_client.py
+++ b/utils/adb_utils/adb_client.py
@@ -1,0 +1,90 @@
+"""High level ADB client built on top of :mod:`adb_runner` utilities.
+
+This module provides an object-oriented interface for common ADB
+operations.  It delegates command execution to
+:func:`utils.adb_utils.adb_runner.run_adb_command` which already
+implements device selection, readiness checks and logging.  The class
+exposes convenience methods for frequently used ADB commands to keep the
+rest of the codebase tidy and expressive.
+"""
+
+from __future__ import annotations
+
+from typing import List, Dict, Optional, Union
+import subprocess
+
+from . import adb_runner
+
+
+Result = Dict[str, Union[bool, str]]
+
+
+class ADBClient:
+    """Simple wrapper around the raw ADB command utilities.
+
+    Parameters
+    ----------
+    serial:
+        Optional device serial.  When omitted, commands that require a
+        target device will attempt auto-discovery in
+        :func:`adb_runner.run_adb_command`.
+    """
+
+    def __init__(self, serial: Optional[str] = None) -> None:
+        self.serial = serial
+
+    # ------------------------------------------------------------------
+    # Static helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def list_devices() -> List[str]:
+        """Return a list of attached device serials."""
+        res = adb_runner.run_adb_command(None, ["devices"])
+        if not res.get("success"):
+            return []
+        lines = [l for l in res.get("output", "").splitlines()[1:] if l.strip()]
+        return [l.split()[0] for l in lines]
+
+    # ------------------------------------------------------------------
+    # Core execution helpers
+    # ------------------------------------------------------------------
+    def ensure_ready(self) -> Result:
+        """Ensure the device is connected and in a "device" state."""
+        if not self.serial:
+            return {"success": False, "output": "", "error": "No device serial specified"}
+        return adb_runner.ensure_device_ready(self.serial)
+
+    def run(self, args: List[str], **kwargs) -> Result:
+        """Run an arbitrary adb command for the configured serial."""
+        return adb_runner.run_adb_command(self.serial, args, **kwargs)
+
+    # ------------------------------------------------------------------
+    # High level convenience methods
+    # ------------------------------------------------------------------
+    def shell(self, command: str) -> Result:
+        """Execute a non-interactive shell command."""
+        return self.run(["shell", command])
+
+    def interactive_shell(self) -> Result:
+        """Open an interactive shell session for the device."""
+        ready = self.ensure_ready()
+        if not ready.get("success"):
+            return ready
+        subprocess.run(["adb", "-s", self.serial, "shell"])
+        return {"success": True, "output": "", "error": ""}
+
+    def reboot(self) -> Result:
+        """Reboot the device."""
+        return self.run(["reboot"])
+
+    def install_apk(self, apk_path: str) -> Result:
+        """Install an APK onto the device."""
+        return self.run(["install", apk_path])
+
+    def push(self, local: str, remote: str) -> Result:
+        """Push a file from local to remote path."""
+        return self.run(["push", local, remote])
+
+    def pull(self, remote: str, local: str) -> Result:
+        """Pull a file from the device."""
+        return self.run(["pull", remote, local])

--- a/utils/test_utils/test_runner.py
+++ b/utils/test_utils/test_runner.py
@@ -1,0 +1,48 @@
+"""Helpers for running the project's test suite.
+
+Providing a lightweight class for invoking ``pytest`` keeps the
+responsibility of process management out of the menu layer and allows for
+easier testing and future extensibility (e.g. collecting coverage or
+passing through additional flags).
+"""
+
+from __future__ import annotations
+
+from typing import List
+import subprocess
+
+import utils.logging_utils.logging_engine as log
+
+
+class PytestRunner:
+    """Thin wrapper around ``pytest`` execution."""
+
+    def __init__(self, args: List[str] | None = None) -> None:
+        self.args = args or ["pytest"]
+
+    def run(self) -> subprocess.CompletedProcess:
+        """Execute pytest with the configured arguments."""
+        return subprocess.run(self.args, text=True)
+
+    # The run_and_report function prints status to the console and logs the
+    # outcome.  It returns ``True`` when all tests succeed.
+    def run_and_report(self) -> bool:
+        try:
+            result = self.run()
+        except Exception as exc:  # pragma: no cover - defensive
+            print(f"❌ Failed to run tests: {exc}\n")
+            log.error(f"Failed to run tests: {exc}")
+            return False
+
+        if result.returncode == 0:
+            print("\n✅ All tests passed.\n")
+            log.info("Test suite completed successfully")
+            return True
+
+        print("\n❌ Some tests failed. Review output above.\n")
+        log.error("Test suite encountered failures")
+        return False
+
+
+__all__ = ["PytestRunner"]
+


### PR DESCRIPTION
## Summary
- add `ensure_device_ready` helper and invoke before ADB commands
- enforce explicit device choice when multiple devices are attached
- update CLI to use `--device` flag and add tests for multi-device scenarios
- provide a main-menu action to run the full pytest suite with live output
- refactor menu logic into a dedicated `main_menu` module with highlighted options for a cleaner UI
- introduce an object-oriented `ADBClient` wrapper with helpers for shell, reboot and file transfer operations and integrate it into the device menu
- convert the database utilities into a `DatabaseMenu` class and introduce a reusable `PytestRunner`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8baea23fc83278a6aca8463dfb158