### PR TITLE
Add offline social app detection

### DIFF
--- a/analysis/static_analysis/app_categories.py
+++ b/analysis/static_analysis/app_categories.py
@@ -37,41 +37,11 @@ KNOWN_APPS = {
 
 DEFAULT_CATEGORY = "Other"
 
-# Human-friendly labels for select social and messaging packages.  This map is
-# referenced by :mod:`social_app_finder` to keep the list of curated social apps
-# in a single location.
-SOCIAL_APP_LABELS = {
-    # TikTok and variants
-    "com.zhiliaoapp.musically": "TikTok",
-    "com.ss.android.ugc.trill": "TikTok",
-    "com.ss.android.ugc.aweme": "TikTok",
-    "com.ss.android.ugc.aweme.lite": "TikTok Lite",
-    "com.zhiliaoapp.musically.go": "TikTok Lite",
-    "com.tiktok.android": "TikTok",
-
-    # Meta/Facebook ecosystem
-    "com.instagram.android": "Instagram",
-    "com.facebook.katana": "Facebook",
-    "com.facebook.lite": "Facebook Lite",
-    "com.facebook.orca": "Messenger",
-
-    # Messaging platforms
-    "com.whatsapp": "WhatsApp",
-    "com.whatsapp.w4b": "WhatsApp Business",
-    "org.telegram.messenger": "Telegram",
-    "com.discord": "Discord",
-    "com.tencent.mm": "WeChat",
-    "org.thoughtcrime.securesms": "Signal",
-    "jp.naver.line.android": "LINE",
-
-    # Other social platforms
-    "com.snapchat.android": "Snapchat",
-    "com.twitter.android": "Twitter",
-    "com.reddit.frontpage": "Reddit",
-    "com.vkontakte.android": "VK",
-    "com.pinterest": "Pinterest",
-    "com.linkedin.android": "LinkedIn",
-}
+# Human-friendly labels for select social and messaging packages.  The mapping
+# itself now lives in :mod:`config.social_detection` so that both static
+# analysis and CSV detection utilities reference a single source of truth.  The
+# name is preserved here for backward compatibility with existing imports.
+from config.social_detection import SOCIAL_APP_PACKAGES as SOCIAL_APP_LABELS
 
 
 def get_category(package: str) -> str:

--- a/config/social_detection.py
+++ b/config/social_detection.py
@@ -1,0 +1,55 @@
+"""Curated package IDs and keyword tokens for social app detection."""
+
+# Mapping of known social/messaging package identifiers to human-friendly labels.
+SOCIAL_APP_PACKAGES = {
+    # TikTok and variants
+    "com.zhiliaoapp.musically": "TikTok",
+    "com.ss.android.ugc.trill": "TikTok",
+    "com.ss.android.ugc.aweme": "TikTok",
+    "com.ss.android.ugc.aweme.lite": "TikTok Lite",
+    "com.zhiliaoapp.musically.go": "TikTok Lite",
+    "com.tiktok.android": "TikTok",
+
+    # Meta/Facebook ecosystem
+    "com.instagram.android": "Instagram",
+    "com.facebook.katana": "Facebook",
+    "com.facebook.lite": "Facebook Lite",
+    "com.facebook.orca": "Messenger",
+
+    # Messaging platforms
+    "com.whatsapp": "WhatsApp",
+    "com.whatsapp.w4b": "WhatsApp Business",
+    "org.telegram.messenger": "Telegram",
+    "com.discord": "Discord",
+    "com.tencent.mm": "WeChat",
+    "org.thoughtcrime.securesms": "Signal",
+    "jp.naver.line.android": "LINE",
+
+    # Other social platforms
+    "com.snapchat.android": "Snapchat",
+    "com.twitter.android": "Twitter",
+    "com.reddit.frontpage": "Reddit",
+    "com.vkontakte.android": "VK",
+    "com.pinterest": "Pinterest",
+    "com.linkedin.android": "LinkedIn",
+}
+
+# Keyword tokens searched within package names for loose matches.
+KEYWORD_TOKENS = [
+    "tiktok",
+    "facebook",
+    "instagram",
+    "whatsapp",
+    "telegram",
+    "discord",
+    "wechat",
+    "signal",
+    "line",
+    "snap",
+    "snapchat",
+    "twitter",
+    "reddit",
+    "vk",
+    "pinterest",
+    "linkedin",
+]

--- a/detection.py
+++ b/detection.py
@@ -1,0 +1,58 @@
+"""Offline detection of social applications from an APK inventory CSV.
+
+This module loads a CSV inventory (``apk_list.csv`` by default), looks for
+packages installed in the "data" partition, and identifies social applications
+either by an exact package match or via keyword tokens.  When matches are found,
+a report is written to ``reports/social_apps_found.csv``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List
+
+from config.social_detection import SOCIAL_APP_PACKAGES, KEYWORD_TOKENS
+from utils.csv_utils import read_apk_list, write_csv
+
+
+def detect(
+    apk_csv: str | Path = "apk_list.csv",
+    report_csv: str | Path = "reports/social_apps_found.csv",
+) -> List[Dict[str, str]]:
+    """Detect social apps listed in ``apk_csv``.
+
+    Only rows where ``Install_Tier`` is ``"data"`` are considered.  Exact
+    package matches are flagged with ``Detected`` set to ``"Y"`` and a
+    ``Reason`` of ``"exact:<pkg>"``.  Rows whose package names contain any
+    ``KEYWORD_TOKENS`` are marked with ``Detected`` set to ``"?"`` and
+    ``Reason`` of ``"keyword:<token>"``.
+    """
+
+    apk_csv = Path(apk_csv)
+    rows = read_apk_list(apk_csv)
+    hits: List[Dict[str, str]] = []
+    for row in rows:
+        if row.get("Install_Tier") != "data":
+            continue
+        pkg = row.get("Package", "")
+        if pkg in SOCIAL_APP_PACKAGES:
+            row["Detected"] = "Y"
+            row["Reason"] = f"exact:{pkg}"
+            hits.append(row)
+            continue
+        lower_pkg = pkg.lower()
+        token = next((t for t in KEYWORD_TOKENS if t in lower_pkg), None)
+        if token:
+            row["Detected"] = "?"
+            row["Reason"] = f"keyword:{token}"
+            hits.append(row)
+
+    if not hits:
+        return []
+
+    extra_headers = [k for k in hits[0].keys() if k not in ("Package", "APK_Path")]
+    write_csv(report_csv, hits, headers=extra_headers)
+    return hits
+
+
+if __name__ == "__main__":
+    detect()


### PR DESCRIPTION
## Summary
- centralize curated social app packages and keyword tokens
- add detection script to scan apk_list.csv for social apps
- update category utilities to use shared detection config

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8c850f0048327867683bbdf719d78